### PR TITLE
feat(ws): implement tournament creation via WebSocket

### DIFF
--- a/dispatchers/tournaments/create.py
+++ b/dispatchers/tournaments/create.py
@@ -1,0 +1,37 @@
+async def create_tournament_handler(client, message, db, USER_TOKENS, proto, ENCRYPTION_KEYS):
+
+    token = message.get("device_token")
+
+    if token not in USER_TOKENS:
+        return
+
+    session = USER_TOKENS[token]
+    user = session[1]
+
+    from services.tournament_service import TournamentService
+
+    try:
+        tournament = await TournamentService.create_tournament(
+            db=db,
+            data=message,
+            user=user
+        )
+
+        await proto.send_message(
+            {
+                "is_ok": True,
+                "type": "create_tournament",
+                "tournament": tournament
+            },
+            ENCRYPTION_KEYS[client]['key']
+        )
+
+    except Exception as e:
+        await proto.send_message(
+            {
+                "is_ok": False,
+                "type": "create_tournament",
+                "error": str(e)
+            },
+            ENCRYPTION_KEYS[client]['key']
+        )

--- a/servises/tournament_service.py
+++ b/servises/tournament_service.py
@@ -1,0 +1,28 @@
+import time
+
+
+class TournamentService:
+
+    @staticmethod
+    async def create_tournament(db, data, user):
+
+        if user.get("role") != "admin":
+            raise Exception("Access denied")
+
+        if "title" not in data:
+            raise Exception("Invalid tournament data: 'title' is required")
+
+        tournament = {
+            "title": data["title"],
+            "description": data.get("description"),
+            "created_by": user["_id"],
+            "start_date": data.get("start_date"),
+            "end_date": data.get("end_date"),
+            "status": "Draft",
+            "created_at": int(time.time())
+        }
+
+        result = await db["tournaments"].insert_one(tournament)
+
+        tournament["_id"] = str(result.inserted_id)
+        return tournament

--- a/websocket.py
+++ b/websocket.py
@@ -31,6 +31,18 @@ async def message_handler(websocket: WebSocket, message: str):
     elif message['type'] == "echo":
         await proto.send_message({"is_ok": True, "type": "echo", "message": message['message']},
                                  ENCRYPTION_KEYS[websocket]['key'])
+        
+    elif message['type'] == "create_tournament":
+        from dispatchers.tournament.create import create_tournament_handler
+
+        await create_tournament_handler(
+            client=websocket,
+            message=message,
+            db=db,
+            USER_TOKENS=USER_TOKENS,
+            proto=proto,
+            ENCRYPTION_KEYS=ENCRYPTION_KEYS
+        )
     else:
         await err_unknown_request(proto=proto, ENCRYPTION_KEYS=ENCRYPTION_KEYS, client=websocket)
 


### PR DESCRIPTION
* Added create_tournament WebSocket message type
* Implemented handler (dispatchers/tournaments/create.py) for processing tournament creation requests
* Introduced TournamentService with create_tournament business logic
* Added basic validation (admin role check, required title field)
* Persisted tournament data in MongoDB "tournaments" collection
* Set default tournament status to "Draft" and auto-generated created_at timestamp
* Returned created tournament object in response (with stringified _id)
* Integrated new handler into message routing in websocket endpoint

This establishes the first core domain entity (Tournament) and introduces a service layer for business logic separation.