### PR TITLE
feat(ws): add get_tournaments method to retrieve tournaments list

### DIFF
--- a/dispatchers/tournaments/get_all.py
+++ b/dispatchers/tournaments/get_all.py
@@ -1,0 +1,38 @@
+async def get_tournaments_handler(client, message, db, USER_TOKENS, proto, ENCRYPTION_KEYS):
+
+    token = message.get("device_token")
+
+    if token not in USER_TOKENS:
+        await proto.send_message(
+            {
+                "is_ok": False,
+                "type": "get_tournaments",
+                "error": "Invalid token"
+            },
+            ENCRYPTION_KEYS[client]['key']
+        )
+        return
+
+    from services.tournament_service import TournamentService
+
+    try:
+        tournaments = await TournamentService.get_tournaments(db)
+
+        await proto.send_message(
+            {
+                "is_ok": True,
+                "type": "get_tournaments",
+                "tournaments": tournaments
+            },
+            ENCRYPTION_KEYS[client]['key']
+        )
+
+    except Exception as e:
+        await proto.send_message(
+            {
+                "is_ok": False,
+                "type": "get_tournaments",
+                "error": str(e)
+            },
+            ENCRYPTION_KEYS[client]['key']
+        )

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -26,3 +26,16 @@ class TournamentService:
 
         tournament["_id"] = str(result.inserted_id)
         return tournament
+    
+    @staticmethod
+    async def get_tournaments(db):
+        tournaments_cursor = db["tournaments"].find({})
+
+        tournaments = []
+        async for tournament in tournaments_cursor:
+            if "_id" in tournament:
+                del tournament["_id"]
+
+            tournaments.append(tournament)
+
+        return tournaments

--- a/websocket.py
+++ b/websocket.py
@@ -50,6 +50,19 @@ async def message_handler(websocket: WebSocket, message: str):
             proto=proto,
             ENCRYPTION_KEYS=ENCRYPTION_KEYS
         )
+
+    elif message['type'] == "get_tournaments":
+        from dispatchers.tournaments.get_all import get_tournaments_handler
+
+        await get_tournaments_handler(
+            client=websocket,
+            message=message,
+            db=db,
+            USER_TOKENS=USER_TOKENS,
+            proto=proto,
+            ENCRYPTION_KEYS=ENCRYPTION_KEYS
+    )
+
     else:
         await err_unknown_request(proto=proto, ENCRYPTION_KEYS=ENCRYPTION_KEYS, client=websocket)
 


### PR DESCRIPTION
* Implemented new WebSocket message type "get_tournaments"
* Added handler (dispatchers/tournaments/get_all.py) for processing requests
* Introduced TournamentService.get_tournaments method to fetch data from MongoDB
* Retrieved all tournaments from "tournaments" collection
* Removed internal "_id" field from each tournament before sending response
* Added authentication check via device_token
* Integrated handler into WebSocket message routing

This enables clients to fetch the list of tournaments and serves as a foundation for filtering and tournament browsing features.