### PR TITLE
Upgrade MongoDB drivers for Python 3.13 compatibility and add missing…

### DIFF
--- a/dispatchers/utils/dotenv_dispatcher.py
+++ b/dispatchers/utils/dotenv_dispatcher.py
@@ -1,3 +1,6 @@
+import os
 from dotenv import dotenv_values
 
-env_data = dict(dotenv_values("config/.env"))
+env_data = dict(os.environ)
+local_env = dotenv_values("config/.env")
+env_data.update({k: v for k, v in local_env.items() if v is not None})

--- a/main.py
+++ b/main.py
@@ -5,8 +5,18 @@ import motor.motor_asyncio
 import uvicorn
 from websocket import app
 
+db_username = env_data.get("SERVER_DB_USERNAME")
+db_password = env_data.get("SERVER_DB_PASSWORD")
+db_host = env_data["SERVER_DB_IP"]
+db_port = env_data["SERVER_DB_PORT"]
+
+if db_username and db_password:
+    mongo_uri = f"mongodb://{db_username}:{db_password}@{db_host}:{db_port}/"
+else:
+    mongo_uri = f"mongodb://{db_host}:{db_port}/"
+
 client = motor.motor_asyncio.AsyncIOMotorClient(
-    f"mongodb://{env_data['SERVER_DB_USERNAME']}:{env_data['SERVER_DB_PASSWORD']}@{env_data['SERVER_DB_IP']}:{env_data['SERVER_DB_PORT']}/"
+    mongo_uri
 )
 db = client[env_data["SERVER_DB_NAME"]]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 fastapi
 aiofiles
-motor~=2.5.1
+cryptography
+motor~=3.7.1
+pycryptodome
 uvicorn
-pymongo~=3.12.3
+pymongo>=4.9,<5
 uvicorn[standard]


### PR DESCRIPTION
… crypto dependencies

upgrade motor from 2.5.1 to 3.7.1
upgrade pymongo from 3.12.3 to a 4.x compatible range add missing cryptography and pycryptodome dependencies update MongoDB URI construction to support environments without DB username/password restore successful backend import on Python 3.13