### PR TITLE
Return MongoDB _id values in API responses instead of stripping them.

### DIFF
--- a/dispatchers/authentication/auth.py
+++ b/dispatchers/authentication/auth.py
@@ -3,6 +3,7 @@ import uuid
 from fastapi import WebSocket
 import dispatchers.utils.FGProto as FGProto
 from dispatchers.utils.error_templates import err_incorrect_login, err_unknown_mode
+from dispatchers.utils.serializers import serialize_mongo_document
 
 
 async def server_auth(client:WebSocket, message:dict, db:any, USER_TOKENS:dict, proto:FGProto, ENCRYPTION_KEYS:dict, save_tokens:any) -> None:
@@ -18,8 +19,7 @@ async def server_auth_found_user(USER_TOKENS:dict, client:WebSocket, user:dict, 
     token = hashlib.sha256(uuid.uuid4().hex.encode('utf-8')).hexdigest()
     USER_TOKENS[token] = [client, user, False, "login", {"is_frozen": False, "is_online": True, "last_seen": None, "login_at": None}]
     await save_tokens()
-    userr = user.copy()
-    del userr['_id']
+    userr = serialize_mongo_document(user)
     if message['login'].strip() == user['login'].strip():
         if message['password'] == user['password']:
             await proto.send_message({"is_ok": True, "type": "auth", "token": token, "auth_mode": "login", "user": userr}, ENCRYPTION_KEYS[client]['key'])

--- a/dispatchers/authentication/get_me.py
+++ b/dispatchers/authentication/get_me.py
@@ -1,6 +1,7 @@
 from fastapi import WebSocket
 from dispatchers.utils.error_templates import err_invalid_token
 from dispatchers.utils.utils import find_token_by_websocket
+from dispatchers.utils.serializers import serialize_mongo_document
 
 
 async def get_me_handler(client: WebSocket, message: dict, USER_TOKENS: dict, proto, ENCRYPTION_KEYS):
@@ -20,10 +21,7 @@ async def get_me_handler(client: WebSocket, message: dict, USER_TOKENS: dict, pr
         await err_invalid_token(proto, ENCRYPTION_KEYS, client, type="get_me")
         return
 
-    user = session[1].copy()
-
-    if "_id" in user:
-        del user["_id"]
+    user = serialize_mongo_document(session[1])
 
     await proto.send_message(
         {

--- a/dispatchers/authentication/register_account.py
+++ b/dispatchers/authentication/register_account.py
@@ -9,6 +9,7 @@ from dispatchers.utils.error_templates import (
     err_incompl_request,
     err_invalid_password
 )
+from dispatchers.utils.serializers import serialize_mongo_document
 
 
 async def server_register(
@@ -71,7 +72,7 @@ async def server_register_create_user(
     }
 
     result = await db['users'].insert_one(user_doc)
-    user_doc['_id'] = result['_id']
+    user_doc['_id'] = result.inserted_id
 
     token = hashlib.sha256(uuid.uuid4().hex.encode('utf-8')).hexdigest()
     USER_TOKENS[token] = [
@@ -89,7 +90,7 @@ async def server_register_create_user(
             "type":      "register_account",
             "token":     token,
             "auth_mode": "register",
-            "user":      user_doc
+            "user":      serialize_mongo_document(user_doc)
         },
         ENCRYPTION_KEYS[client]['key']
     )

--- a/dispatchers/utils/serializers.py
+++ b/dispatchers/utils/serializers.py
@@ -1,0 +1,18 @@
+from bson import ObjectId
+
+
+def serialize_mongo_value(value):
+    if isinstance(value, ObjectId):
+        return str(value)
+
+    if isinstance(value, dict):
+        return {key: serialize_mongo_value(item) for key, item in value.items()}
+
+    if isinstance(value, list):
+        return [serialize_mongo_value(item) for item in value]
+
+    return value
+
+
+def serialize_mongo_document(document):
+    return serialize_mongo_value(dict(document))

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -1,4 +1,5 @@
 import time
+from dispatchers.utils.serializers import serialize_mongo_document
 
 
 class TournamentService:
@@ -25,7 +26,7 @@ class TournamentService:
         result = await db["tournaments"].insert_one(tournament)
 
         tournament["_id"] = str(result.inserted_id)
-        return tournament
+        return serialize_mongo_document(tournament)
     
     @staticmethod
     async def get_tournaments(db):
@@ -33,9 +34,6 @@ class TournamentService:
 
         tournaments = []
         async for tournament in tournaments_cursor:
-            if "_id" in tournament:
-                del tournament["_id"]
-
-            tournaments.append(tournament)
+            tournaments.append(serialize_mongo_document(tournament))
 
         return tournaments


### PR DESCRIPTION
Add a shared serializer that converts ObjectId values to strings, including nested values. Use it for tournament responses, auth/get_me user responses, and registration responses. Fix registration to use InsertOneResult.inserted_id so newly created users expose their generated _id correctly.