### PR TITLE
fix(auth): assign default Team role on registration

### DIFF
--- a/dispatchers/authentication/register_account.py
+++ b/dispatchers/authentication/register_account.py
@@ -11,6 +11,9 @@ from dispatchers.utils.error_templates import (
 )
 
 
+DEFAULT_REGISTERED_USER_ROLE = "Team"
+
+
 async def server_register(
     client: WebSocket,
     message: dict,
@@ -67,7 +70,7 @@ async def server_register_create_user(
         "email":      message.get('email', '').strip(),
         "full_name":   message.get('full_name', '').strip(),
         "password":   message['password'],
-        "role": message['role']         
+        "role": DEFAULT_REGISTERED_USER_ROLE
     }
 
     result = await db['users'].insert_one(user_doc)


### PR DESCRIPTION
Set the registered user role on the backend instead of reading it from the client payload. This makes registration succeed without a role field and prevents clients from assigning privileged roles during normal registration.