### PR TITLE
Prevent password leakage in auth/profile responses

### DIFF
--- a/dispatchers/authentication/auth.py
+++ b/dispatchers/authentication/auth.py
@@ -3,7 +3,7 @@ import uuid
 from fastapi import WebSocket
 import dispatchers.utils.FGProto as FGProto
 from dispatchers.utils.error_templates import err_incorrect_login, err_unknown_mode
-from dispatchers.utils.serializers import serialize_mongo_document
+from dispatchers.utils.serializers import serialize_public_user
 
 
 async def server_auth(client:WebSocket, message:dict, db:any, USER_TOKENS:dict, proto:FGProto, ENCRYPTION_KEYS:dict, save_tokens:any) -> None:
@@ -19,7 +19,7 @@ async def server_auth_found_user(USER_TOKENS:dict, client:WebSocket, user:dict, 
     token = hashlib.sha256(uuid.uuid4().hex.encode('utf-8')).hexdigest()
     USER_TOKENS[token] = [client, user, False, "login", {"is_frozen": False, "is_online": True, "last_seen": None, "login_at": None}]
     await save_tokens()
-    userr = serialize_mongo_document(user)
+    userr = serialize_public_user(user)
     if message['login'].strip() == user['login'].strip():
         if message['password'] == user['password']:
             await proto.send_message({"is_ok": True, "type": "auth", "token": token, "auth_mode": "login", "user": userr}, ENCRYPTION_KEYS[client]['key'])

--- a/dispatchers/authentication/get_me.py
+++ b/dispatchers/authentication/get_me.py
@@ -1,7 +1,7 @@
 from fastapi import WebSocket
 from dispatchers.utils.error_templates import err_invalid_token
 from dispatchers.utils.utils import find_token_by_websocket
-from dispatchers.utils.serializers import serialize_mongo_document
+from dispatchers.utils.serializers import serialize_public_user
 
 
 async def get_me_handler(client: WebSocket, message: dict, USER_TOKENS: dict, proto, ENCRYPTION_KEYS):
@@ -21,7 +21,7 @@ async def get_me_handler(client: WebSocket, message: dict, USER_TOKENS: dict, pr
         await err_invalid_token(proto, ENCRYPTION_KEYS, client, type="get_me")
         return
 
-    user = serialize_mongo_document(session[1])
+    user = serialize_public_user(session[1])
 
     await proto.send_message(
         {

--- a/dispatchers/authentication/register_account.py
+++ b/dispatchers/authentication/register_account.py
@@ -9,7 +9,7 @@ from dispatchers.utils.error_templates import (
     err_incompl_request,
     err_invalid_password
 )
-from dispatchers.utils.serializers import serialize_mongo_document
+from dispatchers.utils.serializers import serialize_public_user
 
 
 DEFAULT_REGISTERED_USER_ROLE = "Team"
@@ -93,7 +93,7 @@ async def server_register_create_user(
             "type":      "register_account",
             "token":     token,
             "auth_mode": "register",
-            "user":      serialize_mongo_document(user_doc)
+            "user":      serialize_public_user(user_doc)
         },
         ENCRYPTION_KEYS[client]['key']
     )

--- a/dispatchers/authentication/update_user_role.py
+++ b/dispatchers/authentication/update_user_role.py
@@ -1,5 +1,6 @@
 from bson import ObjectId
 from bson.errors import InvalidId
+from dispatchers.utils.serializers import serialize_public_user
 
 
 ALLOWED_ROLES = {"admin", "team", "jury", "organizer"}
@@ -15,19 +16,6 @@ async def send_update_role_error(client, proto, ENCRYPTION_KEYS, error):
         },
         ENCRYPTION_KEYS[client]['key']
     )
-
-
-def serialize_user(user):
-    user_data = user.copy()
-
-    if "_id" in user_data:
-        user_data["_id"] = str(user_data["_id"])
-
-    if "password" in user_data:
-        del user_data["password"]
-
-    return user_data
-
 
 async def sync_active_user_sessions(USER_TOKENS, user_id, role):
     for session in USER_TOKENS.values():
@@ -93,7 +81,7 @@ async def update_user_role_handler(client, message, db, USER_TOKENS, proto, ENCR
         {
             "is_ok": True,
             "type": MESSAGE_TYPE,
-            "user": serialize_user(target_user)
+            "user": serialize_public_user(target_user)
         },
         ENCRYPTION_KEYS[client]['key']
     )

--- a/dispatchers/utils/serializers.py
+++ b/dispatchers/utils/serializers.py
@@ -1,5 +1,7 @@
 from bson import ObjectId
 
+PUBLIC_USER_FIELDS = {"_id", "email", "full_name", "login", "role"}
+
 
 def serialize_mongo_value(value):
     if isinstance(value, ObjectId):
@@ -16,3 +18,13 @@ def serialize_mongo_value(value):
 
 def serialize_mongo_document(document):
     return serialize_mongo_value(dict(document))
+
+
+def serialize_public_user(document):
+    raw_document = dict(document)
+    public_user = {
+        key: raw_document[key]
+        for key in PUBLIC_USER_FIELDS
+        if key in raw_document
+    }
+    return serialize_mongo_value(public_user)


### PR DESCRIPTION
Removed password exposure from user-facing auth and profile handlers by introducing a shared safe public-user serializer. Updated auth, get_me, register_account, and update_user_role to return only whitelisted public user fields instead of full Mongo user documents, and replaced the role-update handler’s ad hoc password stripping with the same centralized serialization path.