### PR TITLE
Fix auth flow to use email lookup

### DIFF
--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -76,10 +76,10 @@
     {
       "title": "AuthRequest",
       "type": "object",
-      "required": ["type", "login", "password"],
+      "required": ["type", "email", "password"],
       "properties": {
         "type": { "const": "auth" },
-        "login": { "type": "string" },
+        "email": { "type": "string" },
         "password": { "type": "string" }
       },
       "additionalProperties": true

--- a/dispatchers/authentication/auth.py
+++ b/dispatchers/authentication/auth.py
@@ -3,8 +3,8 @@ import uuid
 from typing import TYPE_CHECKING, Any
 from fastapi import WebSocket
 from dispatchers.authentication.roles import normalize_user_role
-from dispatchers.utils.error_templates import err_incorrect_login, err_unknown_mode
-from dispatchers.utils.serializers import serialize_mongo_document, serialize_public_user
+from dispatchers.utils.error_templates import err_incorrect_login
+from dispatchers.utils.serializers import serialize_public_user
 
 if TYPE_CHECKING:
     import dispatchers.utils.FGProto as FGProto
@@ -13,8 +13,13 @@ else:
 
 
 async def server_auth(client:WebSocket, message:dict, db:any, USER_TOKENS:dict, proto:FGProto, ENCRYPTION_KEYS:dict, save_tokens:any) -> None:
-    message['login'] = message['login'].strip()
-    user = await db['users'].find_one({"login": message['login']})
+    email = message.get('email', '').strip()
+    if not email:
+        await err_incorrect_login(proto=proto, ENCRYPTION_KEYS=ENCRYPTION_KEYS, client=client)
+        return
+
+    message['email'] = email
+    user = await db['users'].find_one({"email": email})
     if user:
         await server_auth_found_user(db, USER_TOKENS, client, user, proto, ENCRYPTION_KEYS, save_tokens, message)
     else:
@@ -22,6 +27,10 @@ async def server_auth(client:WebSocket, message:dict, db:any, USER_TOKENS:dict, 
 
 
 async def server_auth_found_user(db:any, USER_TOKENS:dict, client:WebSocket, user:dict, proto:FGProto, ENCRYPTION_KEYS:dict, save_tokens:any, message:dict) -> None:
+    if message['password'] != user['password']:
+        await err_incorrect_login(proto=proto, ENCRYPTION_KEYS=ENCRYPTION_KEYS, client=client)
+        return
+
     stored_role = user.get("role")
     normalized_role = normalize_user_role(user)
     if normalized_role and stored_role != normalized_role:
@@ -30,11 +39,5 @@ async def server_auth_found_user(db:any, USER_TOKENS:dict, client:WebSocket, use
     USER_TOKENS[token] = [client, user, False, "login", {"is_frozen": False, "is_online": True, "last_seen": None, "login_at": None}]
     await save_tokens()
     userr = serialize_public_user(user)
-    if message['login'].strip() == user['login'].strip():
-        if message['password'] == user['password']:
-            await proto.send_message({"is_ok": True, "type": "auth", "token": token, "auth_mode": "login", "user": userr}, ENCRYPTION_KEYS[client]['key'])
-        else:
-            await err_incorrect_login(proto=proto, ENCRYPTION_KEYS=ENCRYPTION_KEYS, client=client)
-    else:
-        await err_unknown_mode(proto=proto, ENCRYPTION_KEYS=ENCRYPTION_KEYS, client=client, type=message['type'])
+    await proto.send_message({"is_ok": True, "type": "auth", "token": token, "auth_mode": "login", "user": userr}, ENCRYPTION_KEYS[client]['key'])
 

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -112,14 +112,14 @@ Tournament objects currently use this shape:
 
 ### auth
 
-Authenticates an existing user by login and password.
+Authenticates an existing user by email and password.
 
 Request:
 
 ```json
 {
   "type": "auth",
-  "login": "alice",
+  "email": "alice@example.com",
   "password": "secret123"
 }
 ```

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,110 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from bson import ObjectId
+
+from dispatchers.authentication.auth import server_auth
+
+
+async def test_auth_finds_user_by_email_without_login_field(client, encryption_keys, proto):
+    user_id = ObjectId()
+    user = {
+        "_id": user_id,
+        "email": "alice@example.com",
+        "password": "secret123",
+        "role": "team",
+    }
+    users_collection = type("UsersCollection", (), {})()
+    users_collection.find_one = AsyncMock(return_value=user)
+    users_collection.update_one = AsyncMock()
+    db = {"users": users_collection}
+    user_tokens = {}
+    save_tokens = AsyncMock()
+
+    await server_auth(
+        client=client,
+        message={
+            "type": "auth",
+            "email": " alice@example.com ",
+            "password": "secret123",
+        },
+        db=db,
+        USER_TOKENS=user_tokens,
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
+    )
+
+    users_collection.find_one.assert_awaited_once_with({"email": "alice@example.com"})
+    save_tokens.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is True
+    assert payload["type"] == "auth"
+    assert payload["auth_mode"] == "login"
+    assert payload["user"] == {
+        "_id": str(user_id),
+        "email": "alice@example.com",
+        "role": "team",
+    }
+    assert len(user_tokens) == 1
+
+
+async def test_auth_rejects_wrong_password_without_saving_token(client, encryption_keys, proto):
+    user = {
+        "_id": ObjectId(),
+        "email": "alice@example.com",
+        "password": "secret123",
+        "role": "team",
+    }
+    users_collection = type("UsersCollection", (), {})()
+    users_collection.find_one = AsyncMock(return_value=user)
+    users_collection.update_one = AsyncMock()
+    db = {"users": users_collection}
+    user_tokens = {}
+    save_tokens = AsyncMock()
+
+    await server_auth(
+        client=client,
+        message={
+            "type": "auth",
+            "email": "alice@example.com",
+            "password": "wrong-password",
+        },
+        db=db,
+        USER_TOKENS=user_tokens,
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
+    )
+
+    await asyncio.sleep(0)
+    save_tokens.assert_not_awaited()
+    assert user_tokens == {}
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["err_code"] == "#INCORRECT_LOGIN"
+
+
+async def test_auth_rejects_missing_email(client, encryption_keys, proto):
+    users_collection = type("UsersCollection", (), {})()
+    users_collection.find_one = AsyncMock()
+    db = {"users": users_collection}
+
+    await server_auth(
+        client=client,
+        message={
+            "type": "auth",
+            "password": "secret123",
+        },
+        db=db,
+        USER_TOKENS={},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=AsyncMock(),
+    )
+
+    await asyncio.sleep(0)
+    users_collection.find_one.assert_not_awaited()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["err_code"] == "#INCORRECT_LOGIN"


### PR DESCRIPTION
- Authenticate users by email instead of login to match the database schema
- Update WebSocket auth contract and documentation to require email
- Create auth tokens only after successful password validation
- Add tests for email-based authentication and failed login handling