### PR TITLE
feat: add tournament participant assignment

### DIFF
--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -29,6 +29,10 @@
         "created_by": { "type": "string" },
         "start_date": { "type": ["string", "null"] },
         "end_date": { "type": ["string", "null"] },
+        "participant_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "status": { "type": "string", "const": "Draft" },
         "created_at": { "type": "integer" }
       },
@@ -190,6 +194,32 @@
           "type": "array",
           "items": { "$ref": "#/$defs/tournament" }
         }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "AssignTournamentParticipantsRequest",
+      "type": "object",
+      "required": ["type", "device_token", "tournament_id", "participant_ids"],
+      "properties": {
+        "type": { "const": "assign_tournament_participants" },
+        "device_token": { "type": "string" },
+        "tournament_id": { "type": "string" },
+        "participant_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "AssignTournamentParticipantsSuccessResponse",
+      "type": "object",
+      "required": ["is_ok", "type", "tournament"],
+      "properties": {
+        "is_ok": { "type": "boolean", "const": true },
+        "type": { "const": "assign_tournament_participants" },
+        "tournament": { "$ref": "#/$defs/tournament" }
       },
       "additionalProperties": true
     },

--- a/dispatchers/tournaments/assign_participants.py
+++ b/dispatchers/tournaments/assign_participants.py
@@ -1,0 +1,45 @@
+MESSAGE_TYPE = "assign_tournament_participants"
+
+
+async def send_assign_participants_error(client, proto, ENCRYPTION_KEYS, error):
+    await proto.send_message(
+        {
+            "is_ok": False,
+            "type": MESSAGE_TYPE,
+            "error": error
+        },
+        ENCRYPTION_KEYS[client]['key']
+    )
+
+
+async def assign_tournament_participants_handler(client, message, db, USER_TOKENS, proto, ENCRYPTION_KEYS):
+    token = message.get("device_token")
+
+    if not token or token not in USER_TOKENS:
+        await send_assign_participants_error(client, proto, ENCRYPTION_KEYS, "Authentication required")
+        return
+
+    session = USER_TOKENS[token]
+    user = session[1]
+
+    from services.tournament_service import TournamentService
+
+    try:
+        tournament = await TournamentService.assign_participants(
+            db=db,
+            tournament_id=message.get("tournament_id"),
+            participant_ids=message.get("participant_ids"),
+            user=user
+        )
+
+        await proto.send_message(
+            {
+                "is_ok": True,
+                "type": MESSAGE_TYPE,
+                "tournament": tournament
+            },
+            ENCRYPTION_KEYS[client]['key']
+        )
+
+    except Exception as e:
+        await send_assign_participants_error(client, proto, ENCRYPTION_KEYS, str(e))

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -68,6 +68,27 @@ Known messages:
 }
 ```
 
+### assign_tournament_participants
+
+```json
+{
+  "is_ok": false,
+  "type": "assign_tournament_participants",
+  "error": "Access denied"
+}
+```
+
+Known messages:
+
+- `Authentication required`
+- `Access denied`
+- `Required data is missing`
+- `Invalid tournament_id`
+- `Tournament not found`
+- `Invalid participant_ids`
+- `Invalid user_id`
+- `User not found`
+
 ### update_user_role
 
 ```json

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -101,6 +101,7 @@ Tournament objects currently use this shape:
   "created_by": "string",
   "start_date": "string | null",
   "end_date": "string | null",
+  "participant_ids": ["string"],
   "status": "Draft",
   "created_at": 1710000000
 }
@@ -242,7 +243,7 @@ Known errors:
 
 ### create_tournament
 
-Creates a tournament. The authenticated user must have the `admin` role.
+Creates a tournament. The authenticated user must have the `organizer` role.
 
 Request:
 
@@ -281,6 +282,7 @@ Successful response:
     "created_by": "user-id",
     "start_date": "2026-05-01",
     "end_date": "2026-05-03",
+    "participant_ids": [],
     "status": "Draft",
     "created_at": 1710000000
   }
@@ -335,6 +337,7 @@ Successful response:
       "created_by": "user-id",
       "start_date": "2026-05-01",
       "end_date": "2026-05-03",
+      "participant_ids": ["participant-user-id"],
       "status": "Draft",
       "created_at": 1710000000
     }
@@ -351,6 +354,69 @@ Current inline errors:
   "error": "Invalid token"
 }
 ```
+
+### assign_tournament_participants
+
+Replaces the participant list for a tournament. The authenticated user must have
+the `organizer` role.
+
+Request:
+
+```json
+{
+  "type": "assign_tournament_participants",
+  "device_token": "device-token",
+  "tournament_id": "tournament-id",
+  "participant_ids": ["participant-user-id"]
+}
+```
+
+Required fields:
+
+- `device_token`
+- `tournament_id`
+- `participant_ids`
+
+Successful response:
+
+```json
+{
+  "is_ok": true,
+  "type": "assign_tournament_participants",
+  "tournament": {
+    "_id": "tournament-id",
+    "title": "Spring Cup",
+    "description": "Test event",
+    "created_by": "user-id",
+    "start_date": "2026-05-01",
+    "end_date": "2026-05-03",
+    "participant_ids": ["participant-user-id"],
+    "status": "Draft",
+    "created_at": 1710000000
+  }
+}
+```
+
+Current inline errors:
+
+```json
+{
+  "is_ok": false,
+  "type": "assign_tournament_participants",
+  "error": "Access denied"
+}
+```
+
+Possible error messages include:
+
+- `Authentication required`
+- `Access denied`
+- `Required data is missing`
+- `Invalid tournament_id`
+- `Tournament not found`
+- `Invalid participant_ids`
+- `Invalid user_id`
+- `User not found`
 
 ### update_user_role
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 asyncio_mode = auto
 testpaths = tests
+pythonpath = .

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -1,4 +1,6 @@
 import time
+from bson import ObjectId
+from bson.errors import InvalidId
 from dispatchers.authentication.roles import has_role
 from dispatchers.utils.serializers import serialize_mongo_document
 
@@ -8,7 +10,7 @@ class TournamentService:
     @staticmethod
     async def create_tournament(db, data, user):
 
-        if not has_role(user, "admin"):
+        if not has_role(user, "organizer"):
             raise Exception("Access denied")
 
         if "title" not in data:
@@ -20,6 +22,7 @@ class TournamentService:
             "created_by": user["_id"],
             "start_date": data.get("start_date"),
             "end_date": data.get("end_date"),
+            "participant_ids": [],
             "status": "Draft",
             "created_at": int(time.time())
         }
@@ -38,3 +41,43 @@ class TournamentService:
             tournaments.append(serialize_mongo_document(tournament))
 
         return tournaments
+
+    @staticmethod
+    async def assign_participants(db, tournament_id, participant_ids, user):
+        if not has_role(user, "organizer"):
+            raise Exception("Access denied")
+
+        if not tournament_id or participant_ids is None:
+            raise Exception("Required data is missing")
+
+        try:
+            tournament_object_id = ObjectId(tournament_id)
+        except (InvalidId, TypeError):
+            raise Exception("Invalid tournament_id")
+
+        if not isinstance(participant_ids, list):
+            raise Exception("Invalid participant_ids")
+
+        tournament = await db["tournaments"].find_one({"_id": tournament_object_id})
+        if not tournament:
+            raise Exception("Tournament not found")
+
+        participant_object_ids = []
+        for user_id in participant_ids:
+            try:
+                participant_object_ids.append(ObjectId(user_id))
+            except (InvalidId, TypeError):
+                raise Exception("Invalid user_id")
+
+        for participant_object_id in participant_object_ids:
+            participant = await db["users"].find_one({"_id": participant_object_id})
+            if not participant:
+                raise Exception("User not found")
+
+        await db["tournaments"].update_one(
+            {"_id": tournament_object_id},
+            {"$set": {"participant_ids": participant_object_ids}}
+        )
+
+        tournament["participant_ids"] = participant_object_ids
+        return serialize_mongo_document(tournament)

--- a/tests/test_assign_tournament_participants.py
+++ b/tests/test_assign_tournament_participants.py
@@ -1,0 +1,66 @@
+from bson import ObjectId
+
+from dispatchers.tournaments.assign_participants import assign_tournament_participants_handler
+from tests.test_tournament_service import FakeDb, FakeTournamentCollection, FakeUsersCollection
+
+
+async def test_assign_tournament_participants_handler_requires_authentication(client, encryption_keys, proto):
+    await assign_tournament_participants_handler(
+        client=client,
+        message={"device_token": "missing"},
+        db=FakeDb(),
+        USER_TOKENS={},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "assign_tournament_participants"
+    assert payload["error"] == "Authentication required"
+
+
+async def test_assign_tournament_participants_handler_returns_updated_tournament(client, encryption_keys, proto):
+    token = "organizer-token"
+    tournament_id = ObjectId()
+    participant_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": ObjectId(),
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        ),
+        users=FakeUsersCollection(
+            {
+                participant_id: {"_id": participant_id, "role": "team"},
+            }
+        )
+    )
+
+    await assign_tournament_participants_handler(
+        client=client,
+        message={
+            "device_token": token,
+            "tournament_id": str(tournament_id),
+            "participant_ids": [str(participant_id)],
+        },
+        db=db,
+        USER_TOKENS={
+            token: [client, {"_id": ObjectId(), "role": "organizer"}, False, "login", {}]
+        },
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is True
+    assert payload["type"] == "assign_tournament_participants"
+    assert payload["tournament"]["_id"] == str(tournament_id)
+    assert payload["tournament"]["participant_ids"] == [str(participant_id)]

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -5,44 +5,71 @@ from services.tournament_service import TournamentService
 
 
 class FakeTournamentCollection:
-    def __init__(self):
+    def __init__(self, documents=None):
         self.insert_one_calls = []
+        self.update_one_calls = []
+        self.documents = documents or {}
 
     async def insert_one(self, document):
         self.insert_one_calls.append(document)
         return type("InsertResult", (), {"inserted_id": ObjectId()})()
 
+    async def find_one(self, query):
+        return self.documents.get(query["_id"])
+
+    async def update_one(self, query, update):
+        self.update_one_calls.append((query, update))
+        document = self.documents.get(query["_id"])
+        if document:
+            document.update(update.get("$set", {}))
+
+
+class FakeUsersCollection:
+    def __init__(self, documents=None):
+        self.documents = documents or {}
+
+    async def find_one(self, query):
+        return self.documents.get(query["_id"])
+
 
 class FakeDb:
-    def __init__(self):
-        self.tournaments = FakeTournamentCollection()
+    def __init__(self, tournaments=None, users=None):
+        self.tournaments = tournaments or FakeTournamentCollection()
+        self.users = users or FakeUsersCollection()
 
     def __getitem__(self, name):
-        assert name == "tournaments"
-        return self.tournaments
+        if name == "tournaments":
+            return self.tournaments
+
+        if name == "users":
+            return self.users
+
+        raise KeyError(name)
 
 
 @pytest.mark.asyncio
-async def test_create_tournament_for_admin_returns_serialized_tournament():
+async def test_create_tournament_for_organizer_returns_serialized_tournament():
     db = FakeDb()
     user_id = ObjectId()
 
     result = await TournamentService.create_tournament(
         db=db,
         data={"title": "Spring Cup", "description": "Test event"},
-        user={"_id": user_id, "role": "admin"},
+        user={"_id": user_id, "role": "organizer"},
     )
 
     assert result["title"] == "Spring Cup"
     assert result["description"] == "Test event"
     assert result["created_by"] == str(user_id)
+    assert result["participant_ids"] == []
     assert result["status"] == "Draft"
     assert isinstance(result["_id"], str)
     assert db.tournaments.insert_one_calls[0]["title"] == "Spring Cup"
+    assert db.tournaments.insert_one_calls[0]["participant_ids"] == []
 
 
 @pytest.mark.asyncio
-async def test_create_tournament_rejects_non_admin():
+async def test_create_tournament_rejects_non_organizer():
     db = FakeDb()
 
     with pytest.raises(Exception, match="Access denied"):
@@ -61,5 +88,167 @@ async def test_create_tournament_requires_title():
         await TournamentService.create_tournament(
             db=db,
             data={},
-            user={"_id": ObjectId(), "role": "admin"},
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_assign_participants_for_organizer_updates_tournament():
+    tournament_id = ObjectId()
+    first_user_id = ObjectId()
+    second_user_id = ObjectId()
+    tournaments = FakeTournamentCollection(
+        {
+            tournament_id: {
+                "_id": tournament_id,
+                "title": "Spring Cup",
+                "created_by": ObjectId(),
+                "status": "Draft",
+                "created_at": 1710000000,
+                "participant_ids": [],
+            }
+        }
+    )
+    users = FakeUsersCollection(
+        {
+            first_user_id: {"_id": first_user_id, "role": "team"},
+            second_user_id: {"_id": second_user_id, "role": "team"},
+        }
+    )
+    db = FakeDb(tournaments=tournaments, users=users)
+
+    result = await TournamentService.assign_participants(
+        db=db,
+        tournament_id=str(tournament_id),
+        participant_ids=[str(first_user_id), str(second_user_id)],
+        user={"_id": ObjectId(), "role": "organizer"},
+    )
+
+    assert result["_id"] == str(tournament_id)
+    assert result["participant_ids"] == [str(first_user_id), str(second_user_id)]
+    assert tournaments.update_one_calls == [
+        (
+            {"_id": tournament_id},
+            {"$set": {"participant_ids": [first_user_id, second_user_id]}},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_assign_participants_rejects_non_organizer():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Access denied"):
+        await TournamentService.assign_participants(
+            db=db,
+            tournament_id=str(ObjectId()),
+            participant_ids=[],
+            user={"_id": ObjectId(), "role": "team"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_assign_participants_rejects_invalid_tournament_id():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Invalid tournament_id"):
+        await TournamentService.assign_participants(
+            db=db,
+            tournament_id="not-an-object-id",
+            participant_ids=[],
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_assign_participants_rejects_missing_tournament():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Tournament not found"):
+        await TournamentService.assign_participants(
+            db=db,
+            tournament_id=str(ObjectId()),
+            participant_ids=[],
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_assign_participants_rejects_non_list_participant_ids():
+    tournament_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": ObjectId(),
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        )
+    )
+
+    with pytest.raises(Exception, match="Invalid participant_ids"):
+        await TournamentService.assign_participants(
+            db=db,
+            tournament_id=str(tournament_id),
+            participant_ids=str(ObjectId()),
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_assign_participants_rejects_invalid_user_id():
+    tournament_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": ObjectId(),
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        )
+    )
+
+    with pytest.raises(Exception, match="Invalid user_id"):
+        await TournamentService.assign_participants(
+            db=db,
+            tournament_id=str(tournament_id),
+            participant_ids=["not-an-object-id"],
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_assign_participants_rejects_missing_user():
+    tournament_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": ObjectId(),
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        )
+    )
+
+    with pytest.raises(Exception, match="User not found"):
+        await TournamentService.assign_participants(
+            db=db,
+            tournament_id=str(tournament_id),
+            participant_ids=[str(ObjectId())],
+            user={"_id": ObjectId(), "role": "organizer"},
         )

--- a/websocket.py
+++ b/websocket.py
@@ -63,6 +63,17 @@ async def message_handler(websocket: WebSocket, message: str):
             proto=proto,
             ENCRYPTION_KEYS=ENCRYPTION_KEYS
     )
+    elif message['type'] == "assign_tournament_participants":
+        from dispatchers.tournaments.assign_participants import assign_tournament_participants_handler
+
+        await assign_tournament_participants_handler(
+            client=websocket,
+            message=message,
+            db=db,
+            USER_TOKENS=USER_TOKENS,
+            proto=proto,
+            ENCRYPTION_KEYS=ENCRYPTION_KEYS
+        )
     elif message['type'] == "update_user_role":
         from dispatchers.authentication.update_user_role import update_user_role_handler
 


### PR DESCRIPTION
- allow organizers to create tournaments
- add participant_ids to tournament documents
- add WebSocket handler for assigning tournament participants
- validate tournament and participant user IDs
- update websocket contract, docs, and tests