### PR TITLE
Fix create_tournament auth error response

### DIFF
--- a/dispatchers/tournaments/create.py
+++ b/dispatchers/tournaments/create.py
@@ -1,8 +1,23 @@
+MESSAGE_TYPE = "create_tournament"
+
+
+async def send_create_tournament_error(client, proto, ENCRYPTION_KEYS, error):
+    await proto.send_message(
+        {
+            "is_ok": False,
+            "type": MESSAGE_TYPE,
+            "error": error
+        },
+        ENCRYPTION_KEYS[client]['key']
+    )
+
+
 async def create_tournament_handler(client, message, db, USER_TOKENS, proto, ENCRYPTION_KEYS):
 
     token = message.get("device_token")
 
-    if token not in USER_TOKENS:
+    if not token or token not in USER_TOKENS:
+        await send_create_tournament_error(client, proto, ENCRYPTION_KEYS, "Authentication required")
         return
 
     session = USER_TOKENS[token]
@@ -20,18 +35,11 @@ async def create_tournament_handler(client, message, db, USER_TOKENS, proto, ENC
         await proto.send_message(
             {
                 "is_ok": True,
-                "type": "create_tournament",
+                "type": MESSAGE_TYPE,
                 "tournament": tournament
             },
             ENCRYPTION_KEYS[client]['key']
         )
 
     except Exception as e:
-        await proto.send_message(
-            {
-                "is_ok": False,
-                "type": "create_tournament",
-                "error": str(e)
-            },
-            ENCRYPTION_KEYS[client]['key']
-        )
+        await send_create_tournament_error(client, proto, ENCRYPTION_KEYS, str(e))

--- a/tests/test_create_tournament_handler.py
+++ b/tests/test_create_tournament_handler.py
@@ -1,0 +1,67 @@
+from bson import ObjectId
+
+from dispatchers.tournaments.create import create_tournament_handler
+from tests.test_tournament_service import FakeDb
+
+
+async def test_create_tournament_handler_rejects_invalid_token(client, encryption_keys, proto):
+    await create_tournament_handler(
+        client=client,
+        message={"device_token": "missing", "title": "Spring Cup"},
+        db=FakeDb(),
+        USER_TOKENS={},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    proto.send_message.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "create_tournament"
+    assert payload["error"] == "Authentication required"
+
+
+async def test_create_tournament_handler_rejects_missing_token(client, encryption_keys, proto):
+    await create_tournament_handler(
+        client=client,
+        message={"title": "Spring Cup"},
+        db=FakeDb(),
+        USER_TOKENS={},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    proto.send_message.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "create_tournament"
+    assert payload["error"] == "Authentication required"
+
+
+async def test_create_tournament_handler_returns_created_tournament(client, encryption_keys, proto):
+    token = "organizer-token"
+    user_id = ObjectId()
+    db = FakeDb()
+
+    await create_tournament_handler(
+        client=client,
+        message={
+            "device_token": token,
+            "title": "Spring Cup",
+            "description": "Test event",
+        },
+        db=db,
+        USER_TOKENS={
+            token: [client, {"_id": user_id, "role": "organizer"}, False, "login", {}]
+        },
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    proto.send_message.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is True
+    assert payload["type"] == "create_tournament"
+    assert payload["tournament"]["title"] == "Spring Cup"
+    assert payload["tournament"]["created_by"] == str(user_id)
+    assert db.tournaments.insert_one_calls[0]["title"] == "Spring Cup"


### PR DESCRIPTION
Ensure create_tournament_handler sends an explicit error response when device_token is missing or invalid instead of returning silently. Add handler tests for invalid token, missing token, and successful tournament creation.