### PR TITLE
Implement update_tournament WebSocket flow

### DIFF
--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -34,7 +34,8 @@
           "items": { "type": "string" }
         },
         "status": { "type": "string", "const": "Draft" },
-        "created_at": { "type": "integer" }
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" }
       },
       "additionalProperties": true
     },
@@ -169,6 +170,32 @@
       "properties": {
         "is_ok": { "type": "boolean", "const": true },
         "type": { "const": "create_tournament" },
+        "tournament": { "$ref": "#/$defs/tournament" }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "UpdateTournamentRequest",
+      "type": "object",
+      "required": ["type", "device_token", "tournament_id"],
+      "properties": {
+        "type": { "const": "update_tournament" },
+        "device_token": { "type": "string" },
+        "tournament_id": { "type": "string" },
+        "title": { "type": "string" },
+        "description": { "type": ["string", "null"] },
+        "start_date": { "type": ["string", "null"] },
+        "end_date": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "UpdateTournamentSuccessResponse",
+      "type": "object",
+      "required": ["is_ok", "type", "tournament"],
+      "properties": {
+        "is_ok": { "type": "boolean", "const": true },
+        "type": { "const": "update_tournament" },
         "tournament": { "$ref": "#/$defs/tournament" }
       },
       "additionalProperties": true

--- a/dispatchers/tournaments/update.py
+++ b/dispatchers/tournaments/update.py
@@ -1,0 +1,45 @@
+MESSAGE_TYPE = "update_tournament"
+
+
+async def send_update_tournament_error(client, proto, ENCRYPTION_KEYS, error):
+    await proto.send_message(
+        {
+            "is_ok": False,
+            "type": MESSAGE_TYPE,
+            "error": error
+        },
+        ENCRYPTION_KEYS[client]['key']
+    )
+
+
+async def update_tournament_handler(client, message, db, USER_TOKENS, proto, ENCRYPTION_KEYS):
+    token = message.get("device_token")
+
+    if not token or token not in USER_TOKENS:
+        await send_update_tournament_error(client, proto, ENCRYPTION_KEYS, "Authentication required")
+        return
+
+    session = USER_TOKENS[token]
+    user = session[1]
+
+    from services.tournament_service import TournamentService
+
+    try:
+        tournament = await TournamentService.update_tournament(
+            db=db,
+            tournament_id=message.get("tournament_id"),
+            data=message,
+            user=user
+        )
+
+        await proto.send_message(
+            {
+                "is_ok": True,
+                "type": MESSAGE_TYPE,
+                "tournament": tournament
+            },
+            ENCRYPTION_KEYS[client]['key']
+        )
+
+    except Exception as e:
+        await send_update_tournament_error(client, proto, ENCRYPTION_KEYS, str(e))

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -58,6 +58,27 @@ Known messages:
 - `Access denied`
 - `Invalid tournament data: 'title' is required`
 
+### update_tournament
+
+```json
+{
+  "is_ok": false,
+  "type": "update_tournament",
+  "error": "Tournament not found"
+}
+```
+
+Known messages:
+
+- `Authentication required`
+- `Access denied`
+- `Required data is missing`
+- `Invalid tournament_id`
+- `Tournament not found`
+- `Invalid tournament data: 'title' cannot be empty`
+- `Invalid tournament dates`
+- `Invalid tournament dates: 'start_date' must be earlier than 'end_date'`
+
 ### get_tournaments
 
 ```json

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -103,11 +103,13 @@ Tournament objects currently use this shape:
   "end_date": "string | null",
   "participant_ids": ["string"],
   "status": "Draft",
-  "created_at": 1710000000
+  "created_at": 1710000000,
+  "updated_at": 1710000100
 }
 ```
 
-`created_at` is a Unix timestamp in seconds.
+`created_at` and `updated_at` are Unix timestamps in seconds. `updated_at`
+is present after a tournament has been updated.
 
 ## Supported Messages
 
@@ -305,6 +307,79 @@ Possible error messages include:
 - `Invalid tournament data: 'title' is required`
 
 If `device_token` is invalid, the current handler returns no response.
+
+### update_tournament
+
+Updates editable tournament information. The authenticated user must have the
+`organizer` role and must be the tournament creator.
+
+Request:
+
+```json
+{
+  "type": "update_tournament",
+  "device_token": "device-token",
+  "tournament_id": "tournament-id",
+  "title": "Summer Cup",
+  "description": "Updated event",
+  "start_date": "2026-05-10",
+  "end_date": "2026-05-12"
+}
+```
+
+Required fields:
+
+- `device_token`
+- `tournament_id`
+
+Editable fields:
+
+- `title`
+- `description`
+- `start_date`
+- `end_date`
+
+Successful response:
+
+```json
+{
+  "is_ok": true,
+  "type": "update_tournament",
+  "tournament": {
+    "_id": "tournament-id",
+    "title": "Summer Cup",
+    "description": "Updated event",
+    "created_by": "user-id",
+    "start_date": "2026-05-10",
+    "end_date": "2026-05-12",
+    "participant_ids": [],
+    "status": "Draft",
+    "created_at": 1710000000,
+    "updated_at": 1710000100
+  }
+}
+```
+
+Current inline errors:
+
+```json
+{
+  "is_ok": false,
+  "type": "update_tournament",
+  "error": "Tournament not found"
+}
+```
+
+Possible error messages include:
+
+- `Authentication required`
+- `Access denied`
+- `Required data is missing`
+- `Invalid tournament_id`
+- `Tournament not found`
+- `Invalid tournament data: 'title' cannot be empty`
+- `Invalid tournament dates`
+- `Invalid tournament dates: 'start_date' must be earlier than 'end_date'`
 
 ### get_tournaments
 

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from bson import ObjectId
 from bson.errors import InvalidId
 from dispatchers.authentication.roles import has_role
@@ -13,6 +14,7 @@ TOURNAMENT_PUBLIC_FIELDS = {
     "end_date": 1,
     "status": 1,
     "created_at": 1,
+    "updated_at": 1,
 }
 
 async def get_tournament(db, tournament_id: ObjectId) -> dict | None:
@@ -99,4 +101,57 @@ class TournamentService:
         )
 
         tournament["participant_ids"] = participant_object_ids
+        return serialize_mongo_document(tournament)
+
+    @staticmethod
+    async def update_tournament(db, tournament_id, data, user):
+        if not has_role(user, "organizer"):
+            raise Exception("Access denied")
+
+        if not tournament_id:
+            raise Exception("Required data is missing")
+
+        try:
+            tournament_object_id = ObjectId(tournament_id)
+        except (InvalidId, TypeError):
+            raise Exception("Invalid tournament_id")
+
+        tournament = await db["tournaments"].find_one({"_id": tournament_object_id})
+        if not tournament:
+            raise Exception("Tournament not found")
+
+        if tournament.get("created_by") != user["_id"]:
+            raise Exception("Access denied")
+
+        updates = {}
+        editable_fields = ("title", "description", "start_date", "end_date")
+        for field in editable_fields:
+            if field in data:
+                updates[field] = data[field]
+
+        if "title" in updates and (
+            updates["title"] is None or not str(updates["title"]).strip()
+        ):
+            raise Exception("Invalid tournament data: 'title' cannot be empty")
+
+        start_date = updates.get("start_date", tournament.get("start_date"))
+        end_date = updates.get("end_date", tournament.get("end_date"))
+        if start_date is not None and end_date is not None:
+            try:
+                parsed_start = datetime.fromisoformat(start_date)
+                parsed_end = datetime.fromisoformat(end_date)
+            except (TypeError, ValueError):
+                raise Exception("Invalid tournament dates")
+
+            if parsed_start >= parsed_end:
+                raise Exception("Invalid tournament dates: 'start_date' must be earlier than 'end_date'")
+
+        updates["updated_at"] = int(time.time())
+
+        await db["tournaments"].update_one(
+            {"_id": tournament_object_id},
+            {"$set": updates}
+        )
+
+        tournament.update(updates)
         return serialize_mongo_document(tournament)

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -336,3 +336,201 @@ async def test_assign_participants_rejects_missing_user():
             participant_ids=[str(ObjectId())],
             user={"_id": organizer_id, "role": "organizer"},
         )
+
+
+@pytest.mark.asyncio
+async def test_update_tournament_for_organizer_updates_allowed_fields():
+    tournament_id = ObjectId()
+    organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "description": "Old description",
+                    "created_by": organizer_id,
+                    "start_date": "2026-05-10",
+                    "end_date": "2026-05-12",
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        )
+    )
+
+    result = await TournamentService.update_tournament(
+        db=db,
+        tournament_id=str(tournament_id),
+        data={
+            "title": "Summer Cup",
+            "description": "New description",
+            "start_date": "2026-05-11",
+            "end_date": "2026-05-13",
+            "status": "Published",
+        },
+        user={"_id": organizer_id, "role": "organizer"},
+    )
+
+    assert result["_id"] == str(tournament_id)
+    assert result["title"] == "Summer Cup"
+    assert result["description"] == "New description"
+    assert result["start_date"] == "2026-05-11"
+    assert result["end_date"] == "2026-05-13"
+    assert result["status"] == "Draft"
+    assert isinstance(result["updated_at"], int)
+
+    update = db.tournaments.update_one_calls[0][1]["$set"]
+    assert update["title"] == "Summer Cup"
+    assert update["description"] == "New description"
+    assert update["start_date"] == "2026-05-11"
+    assert update["end_date"] == "2026-05-13"
+    assert "status" not in update
+    assert isinstance(update["updated_at"], int)
+
+
+@pytest.mark.asyncio
+async def test_update_tournament_rejects_non_organizer():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Access denied"):
+        await TournamentService.update_tournament(
+            db=db,
+            tournament_id=str(ObjectId()),
+            data={"title": "Summer Cup"},
+            user={"_id": ObjectId(), "role": "team"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_tournament_requires_tournament_id():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Required data is missing"):
+        await TournamentService.update_tournament(
+            db=db,
+            tournament_id=None,
+            data={"title": "Summer Cup"},
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_tournament_rejects_invalid_tournament_id():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Invalid tournament_id"):
+        await TournamentService.update_tournament(
+            db=db,
+            tournament_id="not-an-object-id",
+            data={"title": "Summer Cup"},
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_tournament_rejects_missing_tournament():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Tournament not found"):
+        await TournamentService.update_tournament(
+            db=db,
+            tournament_id=str(ObjectId()),
+            data={"title": "Summer Cup"},
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_tournament_rejects_different_organizer():
+    tournament_id = ObjectId()
+    tournament_owner_id = ObjectId()
+    other_organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": tournament_owner_id,
+                    "start_date": "2026-05-10",
+                    "end_date": "2026-05-12",
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                }
+            }
+        )
+    )
+
+    with pytest.raises(Exception, match="Access denied"):
+        await TournamentService.update_tournament(
+            db=db,
+            tournament_id=str(tournament_id),
+            data={"title": "Summer Cup"},
+            user={"_id": other_organizer_id, "role": "organizer"},
+        )
+
+    assert db.tournaments.update_one_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_tournament_rejects_empty_title():
+    tournament_id = ObjectId()
+    organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": organizer_id,
+                    "start_date": "2026-05-10",
+                    "end_date": "2026-05-12",
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                }
+            }
+        )
+    )
+
+    with pytest.raises(Exception, match="title"):
+        await TournamentService.update_tournament(
+            db=db,
+            tournament_id=str(tournament_id),
+            data={"title": "   "},
+            user={"_id": organizer_id, "role": "organizer"},
+        )
+
+    assert db.tournaments.update_one_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_tournament_rejects_invalid_date_order():
+    tournament_id = ObjectId()
+    organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": organizer_id,
+                    "start_date": "2026-05-10",
+                    "end_date": "2026-05-12",
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                }
+            }
+        )
+    )
+
+    with pytest.raises(Exception, match="start_date"):
+        await TournamentService.update_tournament(
+            db=db,
+            tournament_id=str(tournament_id),
+            data={"start_date": "2026-05-13"},
+            user={"_id": organizer_id, "role": "organizer"},
+        )
+
+    assert db.tournaments.update_one_calls == []

--- a/tests/test_update_tournament_handler.py
+++ b/tests/test_update_tournament_handler.py
@@ -1,0 +1,71 @@
+from bson import ObjectId
+
+from dispatchers.tournaments.update import update_tournament_handler
+from tests.test_tournament_service import FakeDb, FakeTournamentCollection
+
+
+async def test_update_tournament_handler_requires_authentication(client, encryption_keys, proto):
+    await update_tournament_handler(
+        client=client,
+        message={"device_token": "missing", "tournament_id": str(ObjectId())},
+        db=FakeDb(),
+        USER_TOKENS={},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "update_tournament"
+    assert payload["error"] == "Authentication required"
+
+
+async def test_update_tournament_handler_returns_updated_tournament(client, encryption_keys, proto):
+    token = "organizer-token"
+    tournament_id = ObjectId()
+    organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "description": "Old description",
+                    "created_by": organizer_id,
+                    "start_date": "2026-05-10",
+                    "end_date": "2026-05-12",
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        )
+    )
+
+    await update_tournament_handler(
+        client=client,
+        message={
+            "device_token": token,
+            "tournament_id": str(tournament_id),
+            "title": "Summer Cup",
+            "description": "New description",
+            "start_date": "2026-05-11",
+            "end_date": "2026-05-13",
+        },
+        db=db,
+        USER_TOKENS={
+            token: [client, {"_id": organizer_id, "role": "organizer"}, False, "login", {}]
+        },
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is True
+    assert payload["type"] == "update_tournament"
+    assert payload["tournament"]["_id"] == str(tournament_id)
+    assert payload["tournament"]["title"] == "Summer Cup"
+    assert payload["tournament"]["description"] == "New description"
+    assert payload["tournament"]["start_date"] == "2026-05-11"
+    assert payload["tournament"]["end_date"] == "2026-05-13"
+    assert isinstance(payload["tournament"]["updated_at"], int)

--- a/websocket.py
+++ b/websocket.py
@@ -53,6 +53,18 @@ async def message_handler(websocket: WebSocket, message: str):
             ENCRYPTION_KEYS=ENCRYPTION_KEYS
         )
 
+    elif message['type'] == "update_tournament":
+        from dispatchers.tournaments.update import update_tournament_handler
+
+        await update_tournament_handler(
+            client=websocket,
+            message=message,
+            db=db,
+            USER_TOKENS=USER_TOKENS,
+            proto=proto,
+            ENCRYPTION_KEYS=ENCRYPTION_KEYS
+        )
+
     elif message['type'] == "get_tournaments":
         from dispatchers.tournaments.get_all import get_tournaments_handler
 


### PR DESCRIPTION
- add tournament update service with organizer, ownership, title, date, and not-found validation
- add update_tournament WebSocket handler and route
- return updated tournament with updated_at
- document update_tournament request/response/errors
- add service and handler tests