### PR TITLE
Add actual tournaments websocket endpoint

### DIFF
--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -198,6 +198,30 @@
       "additionalProperties": true
     },
     {
+      "title": "GetActualTournamentsRequest",
+      "type": "object",
+      "required": ["type", "device_token"],
+      "properties": {
+        "type": { "const": "get_actual_tournaments" },
+        "device_token": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "GetActualTournamentsSuccessResponse",
+      "type": "object",
+      "required": ["is_ok", "type", "tournaments"],
+      "properties": {
+        "is_ok": { "type": "boolean", "const": true },
+        "type": { "const": "get_actual_tournaments" },
+        "tournaments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/tournament" }
+        }
+      },
+      "additionalProperties": true
+    },
+    {
       "title": "AssignTournamentParticipantsRequest",
       "type": "object",
       "required": ["type", "device_token", "tournament_id", "participant_ids"],

--- a/dispatchers/tournaments/get_actual.py
+++ b/dispatchers/tournaments/get_actual.py
@@ -1,0 +1,41 @@
+MESSAGE_TYPE = "get_actual_tournaments"
+
+
+async def get_actual_tournaments_handler(client, message, db, USER_TOKENS, proto, ENCRYPTION_KEYS):
+    token = message.get("device_token")
+
+    if token not in USER_TOKENS or USER_TOKENS[token][0] != client:
+        await proto.send_message(
+            {
+                "is_ok": False,
+                "type": MESSAGE_TYPE,
+                "error": "Invalid token"
+            },
+            ENCRYPTION_KEYS[client]["key"]
+        )
+        return
+
+    from services.tournament_service import TournamentService
+
+    try:
+        user = USER_TOKENS[token][1]
+        tournaments = await TournamentService.get_actual_tournaments(db, user)
+
+        await proto.send_message(
+            {
+                "is_ok": True,
+                "type": MESSAGE_TYPE,
+                "tournaments": tournaments
+            },
+            ENCRYPTION_KEYS[client]["key"]
+        )
+
+    except Exception as e:
+        await proto.send_message(
+            {
+                "is_ok": False,
+                "type": MESSAGE_TYPE,
+                "error": str(e)
+            },
+            ENCRYPTION_KEYS[client]["key"]
+        )

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -68,6 +68,21 @@ Known messages:
 }
 ```
 
+### get_actual_tournaments
+
+```json
+{
+  "is_ok": false,
+  "type": "get_actual_tournaments",
+  "error": "Invalid token"
+}
+```
+
+Known messages:
+
+- `Invalid token`
+- `Authentication required`
+
 ### assign_tournament_participants
 
 ```json

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -355,6 +355,57 @@ Current inline errors:
 }
 ```
 
+### get_actual_tournaments
+
+Returns tournaments available to the authenticated user. Admins receive all
+actual tournaments, organizers receive actual tournaments they created, and
+participant roles receive actual tournaments where their user id is included in
+`participant_ids`. Archived tournaments are not included.
+
+Request:
+
+```json
+{
+  "type": "get_actual_tournaments",
+  "device_token": "device-token"
+}
+```
+
+Required fields:
+
+- `device_token`
+
+Successful response:
+
+```json
+{
+  "is_ok": true,
+  "type": "get_actual_tournaments",
+  "tournaments": [
+    {
+      "_id": "tournament-id",
+      "title": "Spring Cup",
+      "description": "Test event",
+      "created_by": "user-id",
+      "start_date": "2026-05-01",
+      "end_date": "2026-05-03",
+      "status": "Draft",
+      "created_at": 1710000000
+    }
+  ]
+}
+```
+
+Current inline errors:
+
+```json
+{
+  "is_ok": false,
+  "type": "get_actual_tournaments",
+  "error": "Invalid token"
+}
+```
+
 ### assign_tournament_participants
 
 Replaces the participant list for a tournament. The authenticated user must have

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -15,6 +15,8 @@ TOURNAMENT_PUBLIC_FIELDS = {
     "created_at": 1,
 }
 
+ACTUAL_TOURNAMENT_FILTER = {"status": {"$ne": "Archived"}}
+
 async def get_tournament(db, tournament_id: ObjectId) -> dict | None:
     doc = await db["tournaments"].find_one({"_id": tournament_id}, TOURNAMENT_PUBLIC_FIELDS)
     if not doc:
@@ -51,6 +53,36 @@ class TournamentService:
     @staticmethod
     async def get_tournaments(db):
         tournaments_cursor = db["tournaments"].find({})
+
+        tournaments = []
+        async for tournament in tournaments_cursor:
+            tournaments.append(serialize_mongo_document(tournament))
+
+        return tournaments
+
+    @staticmethod
+    async def get_actual_tournaments(db, user):
+        if not user:
+            raise Exception("Authentication required")
+
+        if has_role(user, "admin"):
+            query = ACTUAL_TOURNAMENT_FILTER
+        elif has_role(user, "organizer"):
+            query = {
+                "$and": [
+                    ACTUAL_TOURNAMENT_FILTER,
+                    {"created_by": user["_id"]},
+                ]
+            }
+        else:
+            query = {
+                "$and": [
+                    ACTUAL_TOURNAMENT_FILTER,
+                    {"participant_ids": user["_id"]},
+                ]
+            }
+
+        tournaments_cursor = db["tournaments"].find(query, TOURNAMENT_PUBLIC_FIELDS)
 
         tournaments = []
         async for tournament in tournaments_cursor:

--- a/tests/test_get_actual_tournaments_handler.py
+++ b/tests/test_get_actual_tournaments_handler.py
@@ -1,0 +1,66 @@
+from bson import ObjectId
+
+from dispatchers.tournaments.get_actual import get_actual_tournaments_handler
+from tests.test_tournament_service import FakeDb, FakeTournamentCollection
+
+
+async def test_get_actual_tournaments_handler_returns_available_tournaments(
+    client,
+    encryption_keys,
+    proto,
+):
+    token = "team-token"
+    participant_id = ObjectId()
+    tournament_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": ObjectId(),
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [participant_id],
+                }
+            }
+        )
+    )
+
+    await get_actual_tournaments_handler(
+        client=client,
+        message={"device_token": token},
+        db=db,
+        USER_TOKENS={
+            token: [client, {"_id": participant_id, "role": "team"}, False, "login", {}]
+        },
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    proto.send_message.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is True
+    assert payload["type"] == "get_actual_tournaments"
+    assert payload["tournaments"][0]["_id"] == str(tournament_id)
+
+
+async def test_get_actual_tournaments_handler_rejects_invalid_token(
+    client,
+    encryption_keys,
+    proto,
+):
+    await get_actual_tournaments_handler(
+        client=client,
+        message={"device_token": "missing"},
+        db=FakeDb(),
+        USER_TOKENS={},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    proto.send_message.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "get_actual_tournaments"
+    assert payload["error"] == "Invalid token"

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -25,11 +25,70 @@ class FakeTournamentCollection:
             if projection.get(key)
         }
 
+    def find(self, query, projection=None):
+        documents = [
+            self._apply_projection(document, projection)
+            for document in self.documents.values()
+            if self._matches_query(document, query)
+        ]
+        return FakeAsyncCursor(documents)
+
     async def update_one(self, query, update):
         self.update_one_calls.append((query, update))
         document = self.documents.get(query["_id"])
         if document:
             document.update(update.get("$set", {}))
+
+    def _apply_projection(self, document, projection):
+        if not projection:
+            return document
+
+        return {
+            key: value
+            for key, value in document.items()
+            if projection.get(key)
+        }
+
+    def _matches_query(self, document, query):
+        if not query:
+            return True
+
+        for key, expected in query.items():
+            if key == "$and":
+                if not all(self._matches_query(document, item) for item in expected):
+                    return False
+                continue
+
+            actual = document.get(key)
+            if isinstance(expected, dict):
+                if "$ne" in expected and actual == expected["$ne"]:
+                    return False
+                continue
+
+            if isinstance(actual, list):
+                if expected not in actual:
+                    return False
+                continue
+
+            if actual != expected:
+                return False
+
+        return True
+
+
+class FakeAsyncCursor:
+    def __init__(self, documents):
+        self.documents = documents
+
+    def __aiter__(self):
+        self._iterator = iter(self.documents)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            raise StopAsyncIteration
 
 
 class FakeUsersCollection:
@@ -141,6 +200,127 @@ async def test_create_tournament_requires_title():
             data={},
             user={"_id": ObjectId(), "role": "organizer"},
         )
+
+
+@pytest.mark.asyncio
+async def test_get_actual_tournaments_for_participant_returns_assigned_tournaments_only():
+    participant_id = ObjectId()
+    other_participant_id = ObjectId()
+    organizer_id = ObjectId()
+    assigned_tournament_id = ObjectId()
+    unassigned_tournament_id = ObjectId()
+    archived_tournament_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                assigned_tournament_id: {
+                    "_id": assigned_tournament_id,
+                    "title": "Assigned Cup",
+                    "created_by": organizer_id,
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [participant_id],
+                },
+                unassigned_tournament_id: {
+                    "_id": unassigned_tournament_id,
+                    "title": "Other Cup",
+                    "created_by": organizer_id,
+                    "status": "Draft",
+                    "created_at": 1710000001,
+                    "participant_ids": [other_participant_id],
+                },
+                archived_tournament_id: {
+                    "_id": archived_tournament_id,
+                    "title": "Archived Cup",
+                    "created_by": organizer_id,
+                    "status": "Archived",
+                    "created_at": 1710000002,
+                    "participant_ids": [participant_id],
+                },
+            }
+        )
+    )
+
+    result = await TournamentService.get_actual_tournaments(
+        db=db,
+        user={"_id": participant_id, "role": "team"},
+    )
+
+    assert [tournament["_id"] for tournament in result] == [str(assigned_tournament_id)]
+    assert "participant_ids" not in result[0]
+
+
+@pytest.mark.asyncio
+async def test_get_actual_tournaments_for_organizer_returns_created_tournaments_only():
+    organizer_id = ObjectId()
+    other_organizer_id = ObjectId()
+    created_tournament_id = ObjectId()
+    other_tournament_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                created_tournament_id: {
+                    "_id": created_tournament_id,
+                    "title": "Created Cup",
+                    "created_by": organizer_id,
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                },
+                other_tournament_id: {
+                    "_id": other_tournament_id,
+                    "title": "Other Organizer Cup",
+                    "created_by": other_organizer_id,
+                    "status": "Draft",
+                    "created_at": 1710000001,
+                    "participant_ids": [organizer_id],
+                },
+            }
+        )
+    )
+
+    result = await TournamentService.get_actual_tournaments(
+        db=db,
+        user={"_id": organizer_id, "role": "organizer"},
+    )
+
+    assert [tournament["_id"] for tournament in result] == [str(created_tournament_id)]
+
+
+@pytest.mark.asyncio
+async def test_get_actual_tournaments_for_admin_returns_all_actual_tournaments():
+    organizer_id = ObjectId()
+    actual_tournament_id = ObjectId()
+    archived_tournament_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                actual_tournament_id: {
+                    "_id": actual_tournament_id,
+                    "title": "Actual Cup",
+                    "created_by": organizer_id,
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                },
+                archived_tournament_id: {
+                    "_id": archived_tournament_id,
+                    "title": "Archived Cup",
+                    "created_by": organizer_id,
+                    "status": "Archived",
+                    "created_at": 1710000001,
+                    "participant_ids": [],
+                },
+            }
+        )
+    )
+
+    result = await TournamentService.get_actual_tournaments(
+        db=db,
+        user={"_id": ObjectId(), "role": "admin"},
+    )
+
+    assert [tournament["_id"] for tournament in result] == [str(actual_tournament_id)]
 
 
 @pytest.mark.asyncio

--- a/websocket.py
+++ b/websocket.py
@@ -63,7 +63,18 @@ async def message_handler(websocket: WebSocket, message: str):
             USER_TOKENS=USER_TOKENS,
             proto=proto,
             ENCRYPTION_KEYS=ENCRYPTION_KEYS
-    )
+        )
+    elif message['type'] == "get_actual_tournaments":
+        from dispatchers.tournaments.get_actual import get_actual_tournaments_handler
+
+        await get_actual_tournaments_handler(
+            client=websocket,
+            message=message,
+            db=db,
+            USER_TOKENS=USER_TOKENS,
+            proto=proto,
+            ENCRYPTION_KEYS=ENCRYPTION_KEYS
+        )
     elif message['type'] == "update_user_role":
         from dispatchers.authentication.update_user_role import update_user_role_handler
 


### PR DESCRIPTION
- add TournamentService.get_actual_tournaments with role-based filtering
- return created tournaments for organizers and assigned tournaments for participants
- add get_actual_tournaments websocket handler and contract docs
- cover admin, organizer, and participant filtering with tests