### PR TITLE
Add WebSocket logout flow

### DIFF
--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -150,6 +150,26 @@
       "additionalProperties": true
     },
     {
+      "title": "LogoutRequest",
+      "type": "object",
+      "required": ["type", "device_token"],
+      "properties": {
+        "type": { "const": "logout" },
+        "device_token": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "LogoutSuccessResponse",
+      "type": "object",
+      "required": ["is_ok", "type"],
+      "properties": {
+        "is_ok": { "type": "boolean", "const": true },
+        "type": { "const": "logout" }
+      },
+      "additionalProperties": true
+    },
+    {
       "title": "CreateTournamentRequest",
       "type": "object",
       "required": ["type", "device_token", "title"],

--- a/dispatchers/authentication/logout.py
+++ b/dispatchers/authentication/logout.py
@@ -1,0 +1,31 @@
+from fastapi import WebSocket
+from dispatchers.utils.error_templates import err_invalid_token
+
+
+async def logout_handler(client: WebSocket, message: dict, USER_TOKENS: dict, proto, ENCRYPTION_KEYS, save_tokens):
+    token = message.get("device_token")
+
+    if not token:
+        await err_invalid_token(proto, ENCRYPTION_KEYS, client, type="logout")
+        return
+
+    if token not in USER_TOKENS:
+        await err_invalid_token(proto, ENCRYPTION_KEYS, client, type="logout")
+        return
+
+    session = USER_TOKENS[token]
+
+    if session[0] != client:
+        await err_invalid_token(proto, ENCRYPTION_KEYS, client, type="logout")
+        return
+
+    del USER_TOKENS[token]
+    await save_tokens()
+
+    await proto.send_message(
+        {
+            "is_ok": True,
+            "type": "logout"
+        },
+        ENCRYPTION_KEYS[client]['key']
+    )

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -243,6 +243,36 @@ Known errors:
 
 - `#INSECURE_CONNECTION`
 
+### logout
+
+Revokes the active server-managed device token for the current WebSocket client.
+
+Request:
+
+```json
+{
+  "type": "logout",
+  "device_token": "device-token"
+}
+```
+
+Required fields:
+
+- `device_token`
+
+Successful response:
+
+```json
+{
+  "is_ok": true,
+  "type": "logout"
+}
+```
+
+Known errors:
+
+- `#INSECURE_CONNECTION`
+
 ### create_tournament
 
 Creates a tournament. The authenticated user must have the `organizer` role.

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,0 +1,107 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from dispatchers.authentication.logout import logout_handler
+
+
+async def test_logout_removes_current_client_token_and_persists(client, encryption_keys, proto):
+    token = "token-1"
+    user_tokens = {
+        token: [client, {"login": "alice"}, False, "login", {}]
+    }
+    save_tokens = AsyncMock()
+
+    await logout_handler(
+        client=client,
+        message={"device_token": token},
+        USER_TOKENS=user_tokens,
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
+    )
+
+    assert token not in user_tokens
+    save_tokens.assert_awaited_once()
+    proto.send_message.assert_awaited_once()
+    payload, used_key = proto.send_message.await_args.args
+    assert payload == {
+        "is_ok": True,
+        "type": "logout",
+    }
+    assert used_key == b"secret"
+
+
+async def test_logout_rejects_missing_token(client, encryption_keys, proto):
+    user_tokens = {
+        "token-1": [client, {"login": "alice"}, False, "login", {}]
+    }
+    save_tokens = AsyncMock()
+
+    await logout_handler(
+        client=client,
+        message={},
+        USER_TOKENS=user_tokens,
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
+    )
+
+    await asyncio.sleep(0)
+    assert "token-1" in user_tokens
+    save_tokens.assert_not_awaited()
+    proto.send_message.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "logout"
+    assert payload["error"] == "Unable to establish a secure connection. Please try again later."
+    assert payload["err_code"] == "#INSECURE_CONNECTION"
+
+
+async def test_logout_rejects_invalid_token(client, encryption_keys, proto):
+    save_tokens = AsyncMock()
+
+    await logout_handler(
+        client=client,
+        message={"device_token": "missing"},
+        USER_TOKENS={},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
+    )
+
+    await asyncio.sleep(0)
+    save_tokens.assert_not_awaited()
+    proto.send_message.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "logout"
+    assert payload["error"] == "Unable to establish a secure connection. Please try again later."
+    assert payload["err_code"] == "#INSECURE_CONNECTION"
+
+
+async def test_logout_rejects_token_for_another_client(client, encryption_keys, proto):
+    other_client = object()
+    token = "token-1"
+    user_tokens = {
+        token: [other_client, {"login": "alice"}, False, "login", {}]
+    }
+    save_tokens = AsyncMock()
+
+    await logout_handler(
+        client=client,
+        message={"device_token": token},
+        USER_TOKENS=user_tokens,
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
+    )
+
+    await asyncio.sleep(0)
+    assert token in user_tokens
+    save_tokens.assert_not_awaited()
+    proto.send_message.assert_awaited_once()
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "logout"
+    assert payload["error"] == "Unable to establish a secure connection. Please try again later."
+    assert payload["err_code"] == "#INSECURE_CONNECTION"

--- a/websocket.py
+++ b/websocket.py
@@ -42,6 +42,18 @@ async def message_handler(websocket: WebSocket, message: str):
             proto=proto,
             ENCRYPTION_KEYS=ENCRYPTION_KEYS
         )
+
+    elif message['type'] == "logout":
+        from dispatchers.authentication.logout import logout_handler
+
+        await logout_handler(
+            client=websocket,
+            message=message,
+            USER_TOKENS=USER_TOKENS,
+            proto=proto,
+            ENCRYPTION_KEYS=ENCRYPTION_KEYS,
+            save_tokens=save_tokens
+        )
         
     elif message['type'] == "create_tournament":
         await create_tournament_handler(


### PR DESCRIPTION
- add logout handler that validates device_token ownership
- revoke active USER_TOKENS session and persist with save_tokens()
- route logout WebSocket messages through the backend
- document logout request/response contract
- add tests for success, missing token, invalid token, and token owned by another client