### PR TITLE
Add search_users WebSocket API

### DIFF
--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -17,7 +17,7 @@
         "login": { "type": "string" },
         "role": { "$ref": "#/$defs/role" }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "tournament": {
       "type": "object",
@@ -299,6 +299,41 @@
         "is_ok": { "type": "boolean", "const": true },
         "type": { "const": "update_user_role" },
         "user": { "$ref": "#/$defs/publicUser" }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "SearchUsersRequest",
+      "type": "object",
+      "required": ["type", "device_token"],
+      "properties": {
+        "type": { "const": "search_users" },
+        "device_token": { "type": "string" },
+        "purpose": {
+          "type": "string",
+          "enum": ["role_management", "tournament_participants"]
+        },
+        "query": { "type": "string" },
+        "search": { "type": "string" },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "SearchUsersSuccessResponse",
+      "type": "object",
+      "required": ["is_ok", "type", "users"],
+      "properties": {
+        "is_ok": { "type": "boolean", "const": true },
+        "type": { "const": "search_users" },
+        "users": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/publicUser" }
+        }
       },
       "additionalProperties": true
     },

--- a/dispatchers/authentication/search_users.py
+++ b/dispatchers/authentication/search_users.py
@@ -1,0 +1,107 @@
+import re
+
+from dispatchers.authentication.roles import has_role, normalize_user_role
+from dispatchers.utils.serializers import PUBLIC_USER_FIELDS, serialize_public_user
+
+
+MESSAGE_TYPE = "search_users"
+USER_PUBLIC_PROJECTION = {field: 1 for field in PUBLIC_USER_FIELDS}
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 100
+ELIGIBLE_PARTICIPANT_ROLES = ("team", "jury")
+
+
+async def send_search_users_error(client, proto, ENCRYPTION_KEYS, error):
+    await proto.send_message(
+        {
+            "is_ok": False,
+            "type": MESSAGE_TYPE,
+            "error": error
+        },
+        ENCRYPTION_KEYS[client]['key']
+    )
+
+
+def parse_limit(value):
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_LIMIT
+
+    if limit < 1:
+        return DEFAULT_LIMIT
+
+    return min(limit, MAX_LIMIT)
+
+
+def build_search_query(search_text):
+    if not search_text or not str(search_text).strip():
+        return {}
+
+    pattern = re.escape(str(search_text).strip())
+    return {
+        "$or": [
+            {"email": {"$regex": pattern, "$options": "i"}},
+            {"full_name": {"$regex": pattern, "$options": "i"}},
+            {"login": {"$regex": pattern, "$options": "i"}},
+        ]
+    }
+
+
+def build_authorized_query(requester, purpose, search_text):
+    base_query = build_search_query(search_text)
+
+    if has_role(requester, "admin"):
+        if purpose not in (None, "role_management"):
+            raise Exception("Access denied")
+        return base_query
+
+    if has_role(requester, "organizer"):
+        if purpose != "tournament_participants":
+            raise Exception("Access denied")
+
+        role_query = {"role": {"$in": ELIGIBLE_PARTICIPANT_ROLES}}
+        if not base_query:
+            return role_query
+
+        return {"$and": [role_query, base_query]}
+
+    raise Exception("Access denied")
+
+
+async def search_users_handler(client, message, db, USER_TOKENS, proto, ENCRYPTION_KEYS):
+    token = message.get("device_token")
+
+    if not token or token not in USER_TOKENS:
+        await send_search_users_error(client, proto, ENCRYPTION_KEYS, "Authentication required")
+        return
+
+    requester = USER_TOKENS[token][1]
+    normalize_user_role(requester)
+
+    try:
+        query = build_authorized_query(
+            requester=requester,
+            purpose=message.get("purpose"),
+            search_text=message.get("query") or message.get("search"),
+        )
+    except Exception as e:
+        await send_search_users_error(client, proto, ENCRYPTION_KEYS, str(e))
+        return
+
+    cursor = db["users"].find(query, USER_PUBLIC_PROJECTION)
+    if hasattr(cursor, "limit"):
+        cursor = cursor.limit(parse_limit(message.get("limit")))
+
+    users = []
+    async for user in cursor:
+        users.append(serialize_public_user(user))
+
+    await proto.send_message(
+        {
+            "is_ok": True,
+            "type": MESSAGE_TYPE,
+            "users": users
+        },
+        ENCRYPTION_KEYS[client]['key']
+    )

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -144,6 +144,21 @@ Known messages:
 - `User not found`
 - `Users cannot change their own role`
 
+### search_users
+
+```json
+{
+  "is_ok": false,
+  "type": "search_users",
+  "error": "Access denied"
+}
+```
+
+Known messages:
+
+- `Authentication required`
+- `Access denied`
+
 ## Recommendation
 
 New handlers should prefer the standard error shape with `err_code`. Existing

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -607,6 +607,74 @@ Possible error messages include:
 - `User not found`
 - `Users cannot change their own role`
 
+### search_users
+
+Searches public user records for role management or tournament participant
+assignment.
+
+Admins may use `purpose: "role_management"` to retrieve users for role
+management. Organizers may use `purpose: "tournament_participants"` to retrieve
+eligible tournament participants.
+
+Request:
+
+```json
+{
+  "type": "search_users",
+  "device_token": "device-token",
+  "purpose": "role_management",
+  "query": "bob",
+  "limit": 20
+}
+```
+
+Required fields:
+
+- `device_token`
+
+Optional fields:
+
+- `purpose`: `role_management` or `tournament_participants`
+- `query`: case-insensitive search text matched against `email`, `full_name`, and `login`
+- `search`: accepted as an alias for `query`
+- `limit`: maximum result count from 1 to 100; defaults to 20
+
+Successful response:
+
+```json
+{
+  "is_ok": true,
+  "type": "search_users",
+  "users": [
+    {
+      "_id": "user-id",
+      "email": "bob@example.com",
+      "full_name": "Bob Example",
+      "login": "bob",
+      "role": "team"
+    }
+  ]
+}
+```
+
+Only public user fields are returned: `_id`, `email`, `full_name`, `login`, and
+`role`. Passwords and private fields are never returned.
+
+Current inline errors:
+
+```json
+{
+  "is_ok": false,
+  "type": "search_users",
+  "error": "Access denied"
+}
+```
+
+Possible error messages include:
+
+- `Authentication required`
+- `Access denied`
+
 ### echo
 
 Returns the provided message payload.

--- a/tests/test_search_users.py
+++ b/tests/test_search_users.py
@@ -1,0 +1,204 @@
+import re
+
+from bson import ObjectId
+
+from dispatchers.authentication.search_users import search_users_handler
+
+
+class FakeAsyncCursor:
+    def __init__(self, documents):
+        self.documents = documents
+        self.limit_value = None
+
+    def limit(self, value):
+        self.limit_value = value
+        self.documents = self.documents[:value]
+        return self
+
+    def __aiter__(self):
+        self._iterator = iter(self.documents)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class FakeUsersCollection:
+    def __init__(self, documents):
+        self.documents = documents
+        self.find_calls = []
+
+    def find(self, query, projection=None):
+        self.find_calls.append((query, projection))
+        documents = [
+            self._apply_projection(document, projection)
+            for document in self.documents
+            if self._matches_query(document, query)
+        ]
+        return FakeAsyncCursor(documents)
+
+    def _apply_projection(self, document, projection):
+        if not projection:
+            return dict(document)
+
+        return {
+            key: value
+            for key, value in document.items()
+            if projection.get(key)
+        }
+
+    def _matches_query(self, document, query):
+        if not query:
+            return True
+
+        for key, expected in query.items():
+            if key == "$and":
+                if not all(self._matches_query(document, item) for item in expected):
+                    return False
+                continue
+
+            if key == "$or":
+                if not any(self._matches_query(document, item) for item in expected):
+                    return False
+                continue
+
+            actual = document.get(key)
+            if isinstance(expected, dict):
+                if "$in" in expected:
+                    if actual not in expected["$in"]:
+                        return False
+                    continue
+
+                if "$regex" in expected:
+                    flags = re.IGNORECASE if expected.get("$options") == "i" else 0
+                    if not re.search(expected["$regex"], str(actual or ""), flags):
+                        return False
+                    continue
+
+            if actual != expected:
+                return False
+
+        return True
+
+
+class FakeDb:
+    def __init__(self, users):
+        self.users = users
+
+    def __getitem__(self, name):
+        if name == "users":
+            return self.users
+
+        raise KeyError(name)
+
+
+async def test_search_users_allows_admin_role_management(client, encryption_keys, proto):
+    first_id = ObjectId()
+    second_id = ObjectId()
+    users = FakeUsersCollection(
+        [
+            {
+                "_id": first_id,
+                "email": "alice@example.com",
+                "full_name": "Alice Example",
+                "login": "alice",
+                "role": "admin",
+                "password": "secret",
+            },
+            {
+                "_id": second_id,
+                "email": "bob@example.com",
+                "full_name": "Bob Example",
+                "login": "bob",
+                "role": "team",
+                "private_note": "hidden",
+            },
+        ]
+    )
+    token = "admin-token"
+
+    await search_users_handler(
+        client=client,
+        message={"device_token": token, "purpose": "role_management", "query": "example"},
+        db=FakeDb(users),
+        USER_TOKENS={token: [client, {"_id": ObjectId(), "role": "admin"}, False, "login", {}]},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is True
+    assert payload["type"] == "search_users"
+    assert [user["_id"] for user in payload["users"]] == [str(first_id), str(second_id)]
+    assert all("password" not in user for user in payload["users"])
+    assert all("private_note" not in user for user in payload["users"])
+
+
+async def test_search_users_allows_organizer_tournament_participants_only(client, encryption_keys, proto):
+    team_id = ObjectId()
+    jury_id = ObjectId()
+    admin_id = ObjectId()
+    users = FakeUsersCollection(
+        [
+            {"_id": team_id, "email": "team@example.com", "full_name": "Team One", "login": "team", "role": "team"},
+            {"_id": jury_id, "email": "jury@example.com", "full_name": "Jury One", "login": "jury", "role": "jury"},
+            {
+                "_id": admin_id,
+                "email": "admin@example.com",
+                "full_name": "Admin One",
+                "login": "admin",
+                "role": "admin",
+            },
+        ]
+    )
+    token = "organizer-token"
+
+    await search_users_handler(
+        client=client,
+        message={"device_token": token, "purpose": "tournament_participants"},
+        db=FakeDb(users),
+        USER_TOKENS={token: [client, {"_id": ObjectId(), "role": "organizer"}, False, "login", {}]},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is True
+    assert [user["_id"] for user in payload["users"]] == [str(team_id), str(jury_id)]
+
+
+async def test_search_users_rejects_unauthenticated_access(client, encryption_keys, proto):
+    await search_users_handler(
+        client=client,
+        message={"device_token": "missing-token", "purpose": "role_management"},
+        db=FakeDb(FakeUsersCollection([])),
+        USER_TOKENS={},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "search_users"
+    assert payload["error"] == "Authentication required"
+
+
+async def test_search_users_rejects_wrong_role(client, encryption_keys, proto):
+    token = "team-token"
+
+    await search_users_handler(
+        client=client,
+        message={"device_token": token, "purpose": "role_management"},
+        db=FakeDb(FakeUsersCollection([])),
+        USER_TOKENS={token: [client, {"_id": ObjectId(), "role": "team"}, False, "login", {}]},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "search_users"
+    assert payload["error"] == "Access denied"

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,6 +1,6 @@
 from bson import ObjectId
 
-from dispatchers.utils.serializers import serialize_mongo_document
+from dispatchers.utils.serializers import serialize_mongo_document, serialize_public_user
 
 
 def test_serialize_mongo_document_converts_nested_object_ids():
@@ -17,4 +17,28 @@ def test_serialize_mongo_document_converts_nested_object_ids():
     assert result == {
         "_id": str(outer_id),
         "items": [{"nested_id": str(inner_id)}],
+    }
+
+
+def test_serialize_public_user_returns_public_fields_only():
+    user_id = ObjectId()
+
+    result = serialize_public_user(
+        {
+            "_id": user_id,
+            "email": "bob@example.com",
+            "full_name": "Bob Example",
+            "login": "bob",
+            "role": "team",
+            "password": "secret",
+            "reset_token": "private",
+        }
+    )
+
+    assert result == {
+        "_id": str(user_id),
+        "email": "bob@example.com",
+        "full_name": "Bob Example",
+        "login": "bob",
+        "role": "team",
     }

--- a/websocket.py
+++ b/websocket.py
@@ -93,6 +93,17 @@ async def message_handler(websocket: WebSocket, message: str):
             proto=proto,
             ENCRYPTION_KEYS=ENCRYPTION_KEYS
         )
+    elif message['type'] == "search_users":
+        from dispatchers.authentication.search_users import search_users_handler
+
+        await search_users_handler(
+            client=websocket,
+            message=message,
+            db=db,
+            USER_TOKENS=USER_TOKENS,
+            proto=proto,
+            ENCRYPTION_KEYS=ENCRYPTION_KEYS
+        )
     elif message['type'] == "assign_tournament_participants":
         from dispatchers.tournaments.assign_participants import assign_tournament_participants_handler
 


### PR DESCRIPTION
- Add search_users handler with RBAC for admin role management and organizer tournament participant lookup
- Return only public user fields via projection and public user serialization
- Register search_users in the WebSocket message router
- Document request/response/error contract and update WebSocket schema
- Add tests for success, unauthorized access, and private-field serialization