### PR TITLE
Include participants in get_tournament response

### DIFF
--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -39,6 +39,26 @@
       },
       "additionalProperties": true
     },
+    "tournamentDetail": {
+      "type": "object",
+      "required": ["_id", "title", "created_by", "status", "created_at", "participants"],
+      "properties": {
+        "_id": { "type": "string" },
+        "title": { "type": "string" },
+        "description": { "type": ["string", "null"] },
+        "created_by": { "type": "string" },
+        "start_date": { "type": ["string", "null"] },
+        "end_date": { "type": ["string", "null"] },
+        "participants": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/publicUser" }
+        },
+        "status": { "type": "string", "const": "Draft" },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
     "standardErrorResponse": {
       "type": "object",
       "required": ["is_ok", "type", "error", "err_code"],
@@ -241,6 +261,28 @@
           "type": "array",
           "items": { "$ref": "#/$defs/tournament" }
         }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "GetTournamentRequest",
+      "type": "object",
+      "required": ["type", "device_token", "tournament_id"],
+      "properties": {
+        "type": { "const": "get_tournament" },
+        "device_token": { "type": "string" },
+        "tournament_id": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "GetTournamentSuccessResponse",
+      "type": "object",
+      "required": ["is_ok", "type", "tournament"],
+      "properties": {
+        "is_ok": { "type": "boolean", "const": true },
+        "type": { "const": "get_tournament" },
+        "tournament": { "$ref": "#/$defs/tournamentDetail" }
       },
       "additionalProperties": true
     },

--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -8,6 +8,10 @@
       "type": "string",
       "enum": ["admin", "team", "jury", "organizer"]
     },
+    "tournamentStatus": {
+      "type": "string",
+      "enum": ["Draft", "Registration", "Running", "Finished"]
+    },
     "publicUser": {
       "type": "object",
       "properties": {
@@ -33,7 +37,7 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "status": { "type": "string", "const": "Draft" },
+        "status": { "$ref": "#/$defs/tournamentStatus" },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" }
       },
@@ -53,7 +57,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/publicUser" }
         },
-        "status": { "type": "string", "const": "Draft" },
+        "status": { "$ref": "#/$defs/tournamentStatus" },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" }
       },
@@ -237,6 +241,29 @@
         "is_ok": { "type": "boolean", "const": true },
         "type": { "const": "update_tournament" },
         "tournament": { "$ref": "#/$defs/tournament" }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "ChangeTournamentStatusRequest",
+      "type": "object",
+      "required": ["type", "device_token", "tournament_id", "status"],
+      "properties": {
+        "type": { "const": "change_tournament_status" },
+        "device_token": { "type": "string" },
+        "tournament_id": { "type": "string" },
+        "status": { "$ref": "#/$defs/tournamentStatus" }
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "ChangeTournamentStatusSuccessResponse",
+      "type": "object",
+      "required": ["is_ok", "type", "tournament"],
+      "properties": {
+        "is_ok": { "type": "boolean", "const": true },
+        "type": { "const": "change_tournament_status" },
+        "tournament": { "$ref": "#/$defs/tournamentDetail" }
       },
       "additionalProperties": true
     },

--- a/dispatchers/tournaments/change_tournament_status.py
+++ b/dispatchers/tournaments/change_tournament_status.py
@@ -1,15 +1,50 @@
+from typing import TYPE_CHECKING, Any
+
 from fastapi import WebSocket
-from bson import ObjectId
-from bson.errors import InvalidId
-import dispatchers.utils.FGProto as FGProto
-from dispatchers.utils.error_templates import (
-    err_empty_token,
-    err_invalid_token,
-    err_incompl_request,
-    err_invalid_id,
-    err_not_found,
-)
-from services.tournament_service import change_tournament_status as service_change_status, ALLOWED_STATUSES
+from services.tournament_service import TournamentService
+
+if TYPE_CHECKING:
+    import dispatchers.utils.FGProto as FGProto
+else:
+    FGProto = Any
+
+
+MESSAGE_TYPE = "change_tournament_status"
+
+
+ERRORS = {
+    "Access denied": ("You do not have permission to perform this action.", "FORBIDDEN"),
+    "Required data is missing": (
+        "Required data is missing. Please check your request and try again.",
+        "INCOMPLETE_REQUEST",
+    ),
+    "Invalid tournament_id": (
+        "Invalid ID provided. Please check your request and try again.",
+        "INVALID_ID",
+    ),
+    "Tournament not found": ("The requested resource was not found.", "NOT_FOUND"),
+}
+
+
+async def send_change_status_error(client, proto, ENCRYPTION_KEYS, message, error_code):
+    await proto.send_message(
+        {
+            "is_ok": False,
+            "type": MESSAGE_TYPE,
+            "error": message,
+            "err_code": f"#{error_code}",
+        },
+        ENCRYPTION_KEYS[client]["key"],
+        client_usr=client,
+    )
+
+
+def map_change_status_error(error):
+    message = str(error)
+    if message.startswith("Invalid status."):
+        return message, "INVALID_STATUS"
+
+    return ERRORS.get(message, (message, "BAD_REQUEST"))
 
 
 async def change_tournament_status(
@@ -20,83 +55,72 @@ async def change_tournament_status(
     proto: FGProto, 
     ENCRYPTION_KEYS: dict
 ) -> None:
-    
+
     if not isinstance(message.get("device_token"), str):
-        await err_empty_token(
-            proto=proto, 
-            ENCRYPTION_KEYS=ENCRYPTION_KEYS, 
-            client=client
-            )
+        await send_change_status_error(
+            client,
+            proto,
+            ENCRYPTION_KEYS,
+            "Authorization token is missing. Please try again later.",
+            "AUTH_TOKEN_EMPTY",
+        )
         return
 
     if not (message["device_token"] in USER_TOKENS and USER_TOKENS[message["device_token"]][0] == client):
-        await err_invalid_token(
-            proto=proto, 
-            ENCRYPTION_KEYS=ENCRYPTION_KEYS, 
-            client=client, 
-            type="change_tournament_status"
-            )
+        await send_change_status_error(
+            client,
+            proto,
+            ENCRYPTION_KEYS,
+            "Unable to establish a secure connection. Please try again later.",
+            "INSECURE_CONNECTION",
+        )
         return
 
-   
     if not message.get("tournament_id") or not message.get("status"):
-        await err_incompl_request(
-            proto=proto, 
-            ENCRYPTION_KEYS=ENCRYPTION_KEYS, 
-            client=client
-            )
-        return
-
-    if message["status"] not in ALLOWED_STATUSES:
-        proto.Error(
-            proto=proto,
-            message=f"Invalid status. Allowed values: {', '.join(ALLOWED_STATUSES)}.",
-            enc_key=ENCRYPTION_KEYS[client]["key"],
-            error_code="INVALID_STATUS",
-            client=client,
-            type="change_tournament_status"
+        await send_change_status_error(
+            client,
+            proto,
+            ENCRYPTION_KEYS,
+            "Required data is missing. Please check your request and try again.",
+            "INCOMPLETE_REQUEST",
         )
         return
 
     user = USER_TOKENS[message["device_token"]][1]
     db_user = await db["users"].find_one({"_id": user["_id"]}, {"role": 1})
 
-    if not db_user or db_user.get("role") != "organizer": 
-        proto.Error(
-            proto=proto,
-            message="You do not have permission to perform this action.",
-            enc_key=ENCRYPTION_KEYS[client]["key"],
-            error_code="FORBIDDEN",
-            client=client,
-            type="change_tournament_status"
+    if not db_user or db_user.get("role") != "organizer":
+        await send_change_status_error(
+            client,
+            proto,
+            ENCRYPTION_KEYS,
+            "You do not have permission to perform this action.",
+            "FORBIDDEN",
         )
         return
 
     try:
-        oid = ObjectId(message["tournament_id"])
-    except (InvalidId, TypeError):
-        await err_invalid_id(
-            proto=proto, 
-            ENCRYPTION_KEYS=ENCRYPTION_KEYS, 
-            client=client, 
-            type="change_tournament_status"
-            )
-        return
-
-    tournament = await service_change_status(db, oid, message["status"])
-
-    if not tournament:
-        await err_not_found(
-            proto=proto, 
-            ENCRYPTION_KEYS=ENCRYPTION_KEYS, 
-            client=client, 
-            type="change_tournament_status"
-            )
+        service_user = {**user, "role": db_user["role"]}
+        tournament = await TournamentService.change_tournament_status(
+            db=db,
+            tournament_id=message["tournament_id"],
+            status=message["status"],
+            user=service_user,
+        )
+    except Exception as error:
+        error_message, error_code = map_change_status_error(error)
+        await send_change_status_error(
+            client,
+            proto,
+            ENCRYPTION_KEYS,
+            error_message,
+            error_code,
+        )
         return
 
     await proto.send_message(
         {"is_ok": True, 
-         "type": "change_tournament_status", 
+         "type": MESSAGE_TYPE, 
          "tournament": tournament
          },
         ENCRYPTION_KEYS[client]["key"],

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -111,6 +111,11 @@ Tournament objects currently use this shape:
 `created_at` and `updated_at` are Unix timestamps in seconds. `updated_at`
 is present after a tournament has been updated.
 
+Tournament detail responses use `participants` instead of `participant_ids`.
+`participants` is always present, is never `null`, and contains public user
+objects. If a stored participant id no longer points to an existing user, that
+user is omitted from `participants`.
+
 ## Supported Messages
 
 ### auth
@@ -457,6 +462,66 @@ Current inline errors:
   "is_ok": false,
   "type": "get_tournaments",
   "error": "Invalid token"
+}
+```
+
+### get_tournament
+
+Returns a single tournament with resolved public participant information.
+
+Request:
+
+```json
+{
+  "type": "get_tournament",
+  "device_token": "device-token",
+  "tournament_id": "tournament-id"
+}
+```
+
+Required fields:
+
+- `device_token`
+- `tournament_id`
+
+Successful response:
+
+```json
+{
+  "is_ok": true,
+  "type": "get_tournament",
+  "tournament": {
+    "_id": "tournament-id",
+    "title": "Spring Cup",
+    "description": "Test event",
+    "created_by": "user-id",
+    "start_date": "2026-05-01",
+    "end_date": "2026-05-03",
+    "participants": [
+      {
+        "_id": "participant-user-id",
+        "email": "participant@example.com",
+        "full_name": "Participant User",
+        "login": "participant",
+        "role": "team"
+      }
+    ],
+    "status": "Draft",
+    "created_at": 1710000000
+  }
+}
+```
+
+When no assigned participants can be resolved, `participants` is returned as
+`[]`.
+
+Current inline errors:
+
+```json
+{
+  "is_ok": false,
+  "type": "get_tournament",
+  "error": "Tournament not found"
 }
 ```
 

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -102,14 +102,15 @@ Tournament objects currently use this shape:
   "start_date": "string | null",
   "end_date": "string | null",
   "participant_ids": ["string"],
-  "status": "Draft",
+  "status": "Draft | Registration | Running | Finished",
   "created_at": 1710000000,
   "updated_at": 1710000100
 }
 ```
 
-`created_at` and `updated_at` are Unix timestamps in seconds. `updated_at`
-is present after a tournament has been updated.
+Allowed tournament statuses are `Draft`, `Registration`, `Running`, and
+`Finished`. `created_at` and `updated_at` are Unix timestamps in seconds.
+`updated_at` is present after a tournament has been updated.
 
 Tournament detail responses use `participants` instead of `participant_ids`.
 `participants` is always present, is never `null`, and contains public user
@@ -415,6 +416,77 @@ Possible error messages include:
 - `Invalid tournament data: 'title' cannot be empty`
 - `Invalid tournament dates`
 - `Invalid tournament dates: 'start_date' must be earlier than 'end_date'`
+
+### change_tournament_status
+
+Changes a tournament status. The authenticated user must have the `organizer`
+role and must be the tournament creator.
+
+Request:
+
+```json
+{
+  "type": "change_tournament_status",
+  "device_token": "device-token",
+  "tournament_id": "tournament-id",
+  "status": "Registration"
+}
+```
+
+Required fields:
+
+- `device_token`
+- `tournament_id`
+- `status`
+
+Allowed `status` values:
+
+- `Draft`
+- `Registration`
+- `Running`
+- `Finished`
+
+Successful response:
+
+```json
+{
+  "is_ok": true,
+  "type": "change_tournament_status",
+  "tournament": {
+    "_id": "tournament-id",
+    "title": "Spring Cup",
+    "description": "Test event",
+    "created_by": "user-id",
+    "start_date": "2026-05-01",
+    "end_date": "2026-05-03",
+    "participants": [],
+    "status": "Registration",
+    "created_at": 1710000000,
+    "updated_at": 1710000100
+  }
+}
+```
+
+Current standard errors:
+
+```json
+{
+  "is_ok": false,
+  "type": "change_tournament_status",
+  "error": "The requested resource was not found.",
+  "err_code": "#NOT_FOUND"
+}
+```
+
+Possible error codes include:
+
+- `#AUTH_TOKEN_EMPTY`
+- `#INSECURE_CONNECTION`
+- `#INCOMPLETE_REQUEST`
+- `#FORBIDDEN`
+- `#INVALID_ID`
+- `#INVALID_STATUS`
+- `#NOT_FOUND`
 
 ### get_tournaments
 

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from bson import ObjectId
 from bson.errors import InvalidId
 from dispatchers.authentication.roles import has_role
-from dispatchers.utils.serializers import serialize_mongo_document
+from dispatchers.utils.serializers import serialize_mongo_document, serialize_public_user
 ALLOWED_STATUSES = {"Draft", "Registration", "Running", "Finished"}
 TOURNAMENT_PUBLIC_FIELDS = {
     "_id": 1,
@@ -16,6 +16,10 @@ TOURNAMENT_PUBLIC_FIELDS = {
     "created_at": 1,
     "updated_at": 1,
 }
+TOURNAMENT_DETAIL_FIELDS = {
+    **TOURNAMENT_PUBLIC_FIELDS,
+    "participant_ids": 1,
+}
 async def change_tournament_status(db, tournament_id: ObjectId, status: str) -> dict | None:
     await db["tournaments"].update_one(
         {"_id": tournament_id},
@@ -27,10 +31,20 @@ async def change_tournament_status(db, tournament_id: ObjectId, status: str) -> 
 ACTUAL_TOURNAMENT_FILTER = {"status": {"$ne": "Archived"}}
 
 async def get_tournament(db, tournament_id: ObjectId) -> dict | None:
-    doc = await db["tournaments"].find_one({"_id": tournament_id}, TOURNAMENT_PUBLIC_FIELDS)
+    doc = await db["tournaments"].find_one({"_id": tournament_id}, TOURNAMENT_DETAIL_FIELDS)
     if not doc:
         return None
-    return serialize_mongo_document(doc)
+
+    participant_ids = doc.pop("participant_ids", []) or []
+    participants = []
+    for participant_id in participant_ids:
+        participant = await db["users"].find_one({"_id": participant_id})
+        if participant:
+            participants.append(serialize_public_user(participant))
+
+    tournament = serialize_mongo_document(doc)
+    tournament["participants"] = participants
+    return tournament
 
 class TournamentService:
 

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -20,12 +20,11 @@ TOURNAMENT_DETAIL_FIELDS = {
     **TOURNAMENT_PUBLIC_FIELDS,
     "participant_ids": 1,
 }
-async def change_tournament_status(db, tournament_id: ObjectId, status: str) -> dict | None:
-    await db["tournaments"].update_one(
-        {"_id": tournament_id},
-        {"$set": {"status": status, "updated_at": int(time.time())}}
-    )
-    return await get_tournament(db, tournament_id)
+async def change_tournament_status(db, tournament_id: ObjectId, status: str, user=None) -> dict | None:
+    if user is None:
+        raise Exception("Access denied")
+
+    return await TournamentService.change_tournament_status(db, tournament_id, status, user)
 
 
 ACTUAL_TOURNAMENT_FILTER = {"status": {"$ne": "Archived"}}
@@ -208,3 +207,34 @@ class TournamentService:
 
         tournament.update(updates)
         return serialize_mongo_document(tournament)
+
+    @staticmethod
+    async def change_tournament_status(db, tournament_id, status, user):
+        if not has_role(user, "organizer"):
+            raise Exception("Access denied")
+
+        if not tournament_id or not status:
+            raise Exception("Required data is missing")
+
+        if status not in ALLOWED_STATUSES:
+            raise Exception(f"Invalid status. Allowed values: {', '.join(sorted(ALLOWED_STATUSES))}.")
+
+        try:
+            tournament_object_id = ObjectId(tournament_id)
+        except (InvalidId, TypeError):
+            raise Exception("Invalid tournament_id")
+
+        tournament = await db["tournaments"].find_one({"_id": tournament_object_id})
+        if not tournament:
+            raise Exception("Tournament not found")
+
+        if tournament.get("created_by") != user["_id"]:
+            raise Exception("Access denied")
+
+        updated_at = int(time.time())
+        await db["tournaments"].update_one(
+            {"_id": tournament_object_id},
+            {"$set": {"status": status, "updated_at": updated_at}}
+        )
+
+        return await get_tournament(db, tournament_object_id)

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -29,6 +29,21 @@ async def change_tournament_status(db, tournament_id: ObjectId, status: str, use
 
 ACTUAL_TOURNAMENT_FILTER = {"status": {"$ne": "Archived"}}
 
+
+def _validate_tournament_dates(start_date, end_date):
+    if start_date is None or end_date is None:
+        return
+
+    try:
+        parsed_start = datetime.fromisoformat(start_date)
+        parsed_end = datetime.fromisoformat(end_date)
+    except (TypeError, ValueError):
+        raise Exception("Invalid tournament dates")
+
+    if parsed_start >= parsed_end:
+        raise Exception("Invalid tournament dates: 'start_date' must be earlier than 'end_date'")
+
+
 async def get_tournament(db, tournament_id: ObjectId) -> dict | None:
     doc = await db["tournaments"].find_one({"_id": tournament_id}, TOURNAMENT_DETAIL_FIELDS)
     if not doc:
@@ -55,6 +70,8 @@ class TournamentService:
 
         if "title" not in data:
             raise Exception("Invalid tournament data: 'title' is required")
+
+        _validate_tournament_dates(data.get("start_date"), data.get("end_date"))
 
         tournament = {
             "title": data["title"],
@@ -188,15 +205,7 @@ class TournamentService:
 
         start_date = updates.get("start_date", tournament.get("start_date"))
         end_date = updates.get("end_date", tournament.get("end_date"))
-        if start_date is not None and end_date is not None:
-            try:
-                parsed_start = datetime.fromisoformat(start_date)
-                parsed_end = datetime.fromisoformat(end_date)
-            except (TypeError, ValueError):
-                raise Exception("Invalid tournament dates")
-
-            if parsed_start >= parsed_end:
-                raise Exception("Invalid tournament dates: 'start_date' must be earlier than 'end_date'")
+        _validate_tournament_dates(start_date, end_date)
 
         updates["updated_at"] = int(time.time())
 

--- a/tests/test_change_tournament_status_handler.py
+++ b/tests/test_change_tournament_status_handler.py
@@ -1,0 +1,245 @@
+from bson import ObjectId
+
+from dispatchers.tournaments.change_tournament_status import change_tournament_status
+from tests.test_tournament_service import FakeDb, FakeTournamentCollection, FakeUsersCollection
+
+
+def user_token(client, token, user_id, role="organizer"):
+    return {
+        token: [client, {"_id": user_id, "role": role}, False, "login", {}]
+    }
+
+
+def db_user(user_id, role="organizer"):
+    return FakeUsersCollection({user_id: {"_id": user_id, "role": role}})
+
+
+async def call_handler(client, encryption_keys, proto, message, db=None, tokens=None):
+    await change_tournament_status(
+        client=client,
+        message=message,
+        db=db or FakeDb(),
+        USER_TOKENS=tokens or {},
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+    )
+
+    return proto.send_message.await_args.args[0]
+
+
+async def test_change_tournament_status_returns_updated_tournament(client, encryption_keys, proto):
+    token = "organizer-token"
+    tournament_id = ObjectId()
+    organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": organizer_id,
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        ),
+        users=db_user(organizer_id),
+    )
+
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {
+            "device_token": token,
+            "tournament_id": str(tournament_id),
+            "status": "Registration",
+        },
+        db=db,
+        tokens=user_token(client, token, organizer_id),
+    )
+
+    assert payload["is_ok"] is True
+    assert payload["type"] == "change_tournament_status"
+    assert payload["tournament"]["_id"] == str(tournament_id)
+    assert payload["tournament"]["status"] == "Registration"
+    assert isinstance(payload["tournament"]["updated_at"], int)
+
+
+async def test_change_tournament_status_rejects_missing_token(client, encryption_keys, proto):
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {"tournament_id": str(ObjectId()), "status": "Registration"},
+    )
+
+    assert payload["is_ok"] is False
+    assert payload["type"] == "change_tournament_status"
+    assert payload["err_code"] == "#AUTH_TOKEN_EMPTY"
+
+
+async def test_change_tournament_status_rejects_invalid_token(client, encryption_keys, proto):
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {
+            "device_token": "missing-token",
+            "tournament_id": str(ObjectId()),
+            "status": "Registration",
+        },
+    )
+
+    assert payload["is_ok"] is False
+    assert payload["type"] == "change_tournament_status"
+    assert payload["err_code"] == "#INSECURE_CONNECTION"
+
+
+async def test_change_tournament_status_rejects_missing_required_fields(client, encryption_keys, proto):
+    token = "organizer-token"
+    organizer_id = ObjectId()
+
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {"device_token": token, "status": "Registration"},
+        tokens=user_token(client, token, organizer_id),
+    )
+
+    assert payload["is_ok"] is False
+    assert payload["type"] == "change_tournament_status"
+    assert payload["err_code"] == "#INCOMPLETE_REQUEST"
+
+
+async def test_change_tournament_status_rejects_non_organizer(client, encryption_keys, proto):
+    token = "team-token"
+    user_id = ObjectId()
+    db = FakeDb(users=db_user(user_id, role="team"))
+
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {
+            "device_token": token,
+            "tournament_id": str(ObjectId()),
+            "status": "Registration",
+        },
+        db=db,
+        tokens=user_token(client, token, user_id, role="team"),
+    )
+
+    assert payload["is_ok"] is False
+    assert payload["type"] == "change_tournament_status"
+    assert payload["err_code"] == "#FORBIDDEN"
+
+
+async def test_change_tournament_status_rejects_different_organizer(client, encryption_keys, proto):
+    token = "organizer-token"
+    tournament_id = ObjectId()
+    owner_id = ObjectId()
+    other_organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": owner_id,
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        ),
+        users=db_user(other_organizer_id),
+    )
+
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {
+            "device_token": token,
+            "tournament_id": str(tournament_id),
+            "status": "Registration",
+        },
+        db=db,
+        tokens=user_token(client, token, other_organizer_id),
+    )
+
+    assert payload["is_ok"] is False
+    assert payload["type"] == "change_tournament_status"
+    assert payload["err_code"] == "#FORBIDDEN"
+
+
+async def test_change_tournament_status_rejects_invalid_tournament_id(client, encryption_keys, proto):
+    token = "organizer-token"
+    organizer_id = ObjectId()
+    db = FakeDb(users=db_user(organizer_id))
+
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {
+            "device_token": token,
+            "tournament_id": "not-an-object-id",
+            "status": "Registration",
+        },
+        db=db,
+        tokens=user_token(client, token, organizer_id),
+    )
+
+    assert payload["is_ok"] is False
+    assert payload["type"] == "change_tournament_status"
+    assert payload["err_code"] == "#INVALID_ID"
+
+
+async def test_change_tournament_status_rejects_missing_tournament(client, encryption_keys, proto):
+    token = "organizer-token"
+    organizer_id = ObjectId()
+    db = FakeDb(users=db_user(organizer_id))
+
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {
+            "device_token": token,
+            "tournament_id": str(ObjectId()),
+            "status": "Registration",
+        },
+        db=db,
+        tokens=user_token(client, token, organizer_id),
+    )
+
+    assert payload["is_ok"] is False
+    assert payload["type"] == "change_tournament_status"
+    assert payload["err_code"] == "#NOT_FOUND"
+
+
+async def test_change_tournament_status_rejects_invalid_status(client, encryption_keys, proto):
+    token = "organizer-token"
+    organizer_id = ObjectId()
+    db = FakeDb(users=db_user(organizer_id))
+
+    payload = await call_handler(
+        client,
+        encryption_keys,
+        proto,
+        {
+            "device_token": token,
+            "tournament_id": str(ObjectId()),
+            "status": "Published",
+        },
+        db=db,
+        tokens=user_token(client, token, organizer_id),
+    )
+
+    assert payload["is_ok"] is False
+    assert payload["type"] == "change_tournament_status"
+    assert payload["err_code"] == "#INVALID_STATUS"

--- a/tests/test_get_tournament.py
+++ b/tests/test_get_tournament.py
@@ -3,13 +3,14 @@ import asyncio
 from bson import ObjectId
 
 from dispatchers.tournaments.tournament_get import get_tournament
-from tests.test_tournament_service import FakeDb, FakeTournamentCollection
+from tests.test_tournament_service import FakeDb, FakeTournamentCollection, FakeUsersCollection
 
 
 async def test_get_tournament_handler_returns_tournament(client, encryption_keys, proto):
     token = "organizer-token"
     tournament_id = ObjectId()
     organizer_id = ObjectId()
+    participant_id = ObjectId()
     db = FakeDb(
         tournaments=FakeTournamentCollection(
             {
@@ -20,10 +21,22 @@ async def test_get_tournament_handler_returns_tournament(client, encryption_keys
                     "created_by": organizer_id,
                     "status": "Draft",
                     "created_at": 1710000000,
-                    "participant_ids": [ObjectId()],
+                    "participant_ids": [participant_id],
                 }
             }
-        )
+        ),
+        users=FakeUsersCollection(
+            {
+                participant_id: {
+                    "_id": participant_id,
+                    "email": "participant@example.com",
+                    "full_name": "Participant User",
+                    "login": "participant",
+                    "role": "team",
+                    "password": "secret",
+                }
+            }
+        ),
     )
 
     await get_tournament(
@@ -45,6 +58,15 @@ async def test_get_tournament_handler_returns_tournament(client, encryption_keys
     assert payload["type"] == "get_tournament"
     assert payload["tournament"]["_id"] == str(tournament_id)
     assert payload["tournament"]["created_by"] == str(organizer_id)
+    assert payload["tournament"]["participants"] == [
+        {
+            "_id": str(participant_id),
+            "email": "participant@example.com",
+            "full_name": "Participant User",
+            "login": "participant",
+            "role": "team",
+        }
+    ]
     assert "participant_ids" not in payload["tournament"]
     assert used_key == b"secret"
 

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -118,6 +118,7 @@ class FakeDb:
 async def test_get_tournament_returns_serialized_public_fields_only():
     tournament_id = ObjectId()
     organizer_id = ObjectId()
+    participant_id = ObjectId()
     db = FakeDb(
         tournaments=FakeTournamentCollection(
             {
@@ -130,10 +131,23 @@ async def test_get_tournament_returns_serialized_public_fields_only():
                     "end_date": "2026-05-11",
                     "status": "Draft",
                     "created_at": 1710000000,
-                    "participant_ids": [ObjectId()],
+                    "participant_ids": [participant_id],
                 }
             }
-        )
+        ),
+        users=FakeUsersCollection(
+            {
+                participant_id: {
+                    "_id": participant_id,
+                    "email": "participant@example.com",
+                    "full_name": "Participant User",
+                    "login": "participant",
+                    "role": "team",
+                    "password": "secret",
+                    "device_tokens": ["private-token"],
+                }
+            }
+        ),
     )
 
     result = await get_tournament(db, tournament_id)
@@ -147,7 +161,86 @@ async def test_get_tournament_returns_serialized_public_fields_only():
         "end_date": "2026-05-11",
         "status": "Draft",
         "created_at": 1710000000,
+        "participants": [
+            {
+                "_id": str(participant_id),
+                "email": "participant@example.com",
+                "full_name": "Participant User",
+                "login": "participant",
+                "role": "team",
+            }
+        ],
     }
+
+
+@pytest.mark.asyncio
+async def test_get_tournament_returns_empty_participants_when_none_assigned():
+    tournament_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": ObjectId(),
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        )
+    )
+
+    result = await get_tournament(db, tournament_id)
+
+    assert result["participants"] == []
+    assert "participant_ids" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_tournament_skips_missing_participant_users():
+    tournament_id = ObjectId()
+    existing_participant_id = ObjectId()
+    missing_participant_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": ObjectId(),
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [existing_participant_id, missing_participant_id],
+                }
+            }
+        ),
+        users=FakeUsersCollection(
+            {
+                existing_participant_id: {
+                    "_id": existing_participant_id,
+                    "email": "existing@example.com",
+                    "full_name": "Existing User",
+                    "login": "existing",
+                    "role": "team",
+                    "password": "secret",
+                }
+            }
+        ),
+    )
+
+    result = await get_tournament(db, tournament_id)
+
+    assert result["participants"] == [
+        {
+            "_id": str(existing_participant_id),
+            "email": "existing@example.com",
+            "full_name": "Existing User",
+            "login": "existing",
+            "role": "team",
+        }
+    ]
+    assert "participant_ids" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -95,8 +95,16 @@ class FakeUsersCollection:
     def __init__(self, documents=None):
         self.documents = documents or {}
 
-    async def find_one(self, query):
-        return self.documents.get(query["_id"])
+    async def find_one(self, query, projection=None):
+        document = self.documents.get(query["_id"])
+        if not document or not projection:
+            return document
+
+        return {
+            key: value
+            for key, value in document.items()
+            if projection.get(key)
+        }
 
 
 class FakeDb:
@@ -807,3 +815,121 @@ async def test_update_tournament_rejects_invalid_date_order():
         )
 
     assert db.tournaments.update_one_calls == []
+
+
+@pytest.mark.asyncio
+async def test_change_tournament_status_for_owner_updates_status_and_timestamp():
+    tournament_id = ObjectId()
+    organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": organizer_id,
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        )
+    )
+
+    result = await TournamentService.change_tournament_status(
+        db=db,
+        tournament_id=str(tournament_id),
+        status="Registration",
+        user={"_id": organizer_id, "role": "organizer"},
+    )
+
+    assert result["_id"] == str(tournament_id)
+    assert result["status"] == "Registration"
+    assert isinstance(result["updated_at"], int)
+
+    update = db.tournaments.update_one_calls[0][1]["$set"]
+    assert update["status"] == "Registration"
+    assert isinstance(update["updated_at"], int)
+
+
+@pytest.mark.asyncio
+async def test_change_tournament_status_rejects_non_organizer():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Access denied"):
+        await TournamentService.change_tournament_status(
+            db=db,
+            tournament_id=str(ObjectId()),
+            status="Registration",
+            user={"_id": ObjectId(), "role": "team"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_change_tournament_status_rejects_different_organizer():
+    tournament_id = ObjectId()
+    tournament_owner_id = ObjectId()
+    other_organizer_id = ObjectId()
+    db = FakeDb(
+        tournaments=FakeTournamentCollection(
+            {
+                tournament_id: {
+                    "_id": tournament_id,
+                    "title": "Spring Cup",
+                    "created_by": tournament_owner_id,
+                    "status": "Draft",
+                    "created_at": 1710000000,
+                    "participant_ids": [],
+                }
+            }
+        )
+    )
+
+    with pytest.raises(Exception, match="Access denied"):
+        await TournamentService.change_tournament_status(
+            db=db,
+            tournament_id=str(tournament_id),
+            status="Registration",
+            user={"_id": other_organizer_id, "role": "organizer"},
+        )
+
+    assert db.tournaments.update_one_calls == []
+
+
+@pytest.mark.asyncio
+async def test_change_tournament_status_rejects_invalid_tournament_id():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Invalid tournament_id"):
+        await TournamentService.change_tournament_status(
+            db=db,
+            tournament_id="not-an-object-id",
+            status="Registration",
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_change_tournament_status_rejects_missing_tournament():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Tournament not found"):
+        await TournamentService.change_tournament_status(
+            db=db,
+            tournament_id=str(ObjectId()),
+            status="Registration",
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_change_tournament_status_rejects_invalid_status():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Invalid status"):
+        await TournamentService.change_tournament_status(
+            db=db,
+            tournament_id=str(ObjectId()),
+            status="Published",
+            user={"_id": ObjectId(), "role": "organizer"},
+        )

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -277,6 +277,83 @@ async def test_create_tournament_for_organizer_returns_serialized_tournament():
     assert isinstance(result["_id"], str)
     assert db.tournaments.insert_one_calls[0]["title"] == "Spring Cup"
     assert db.tournaments.insert_one_calls[0]["participant_ids"] == []
+    assert db.tournaments.insert_one_calls[0]["start_date"] is None
+    assert db.tournaments.insert_one_calls[0]["end_date"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_tournament_accepts_valid_dates():
+    db = FakeDb()
+    user_id = ObjectId()
+
+    result = await TournamentService.create_tournament(
+        db=db,
+        data={
+            "title": "Spring Cup",
+            "start_date": "2026-05-10T10:00:00",
+            "end_date": "2026-05-11T10:00:00",
+        },
+        user={"_id": user_id, "role": "organizer"},
+    )
+
+    assert result["start_date"] == "2026-05-10T10:00:00"
+    assert result["end_date"] == "2026-05-11T10:00:00"
+    assert db.tournaments.insert_one_calls[0]["start_date"] == "2026-05-10T10:00:00"
+    assert db.tournaments.insert_one_calls[0]["end_date"] == "2026-05-11T10:00:00"
+
+
+@pytest.mark.asyncio
+async def test_create_tournament_rejects_invalid_date_format():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="Invalid tournament dates"):
+        await TournamentService.create_tournament(
+            db=db,
+            data={
+                "title": "Spring Cup",
+                "start_date": "not-a-date",
+                "end_date": "2026-05-11T10:00:00",
+            },
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+    assert db.tournaments.insert_one_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_tournament_rejects_equal_dates():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="start_date"):
+        await TournamentService.create_tournament(
+            db=db,
+            data={
+                "title": "Spring Cup",
+                "start_date": "2026-05-10T10:00:00",
+                "end_date": "2026-05-10T10:00:00",
+            },
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+    assert db.tournaments.insert_one_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_tournament_rejects_start_date_after_end_date():
+    db = FakeDb()
+
+    with pytest.raises(Exception, match="start_date"):
+        await TournamentService.create_tournament(
+            db=db,
+            data={
+                "title": "Spring Cup",
+                "start_date": "2026-05-12T10:00:00",
+                "end_date": "2026-05-11T10:00:00",
+            },
+            user={"_id": ObjectId(), "role": "organizer"},
+        )
+
+    assert db.tournaments.insert_one_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Resolve tournament participant_ids into public user objects for the get_tournament detail response. Always return participants as an array, omit missing users from the resolved list, and keep participant_ids as the internal storage format.

Update WebSocket schema/docs and add tests for public participant data, empty participants, and stale participant IDs.