### PR TITLE
Rotate device token on get_me reconnect

### DIFF
--- a/contracts/ws-messages.schema.json
+++ b/contracts/ws-messages.schema.json
@@ -172,10 +172,11 @@
     {
       "title": "GetMeSuccessResponse",
       "type": "object",
-      "required": ["is_ok", "type", "user"],
+      "required": ["is_ok", "type", "token", "user"],
       "properties": {
         "is_ok": { "type": "boolean", "const": true },
         "type": { "const": "get_me" },
+        "token": { "type": "string" },
         "user": { "$ref": "#/$defs/publicUser" }
       },
       "additionalProperties": true

--- a/dispatchers/authentication/auth.py
+++ b/dispatchers/authentication/auth.py
@@ -1,8 +1,7 @@
-import hashlib
-import uuid
 from typing import TYPE_CHECKING, Any
 from fastapi import WebSocket
 from dispatchers.authentication.roles import normalize_user_role
+from dispatchers.authentication.tokens import generate_device_token
 from dispatchers.utils.error_templates import err_incorrect_login
 from dispatchers.utils.serializers import serialize_public_user
 
@@ -45,7 +44,7 @@ async def server_auth_found_user(db:any, USER_TOKENS:dict, client:WebSocket, use
     normalized_role = normalize_user_role(user)
     if normalized_role and stored_role != normalized_role:
         await db['users'].update_one({"_id": user["_id"]}, {"$set": {"role": normalized_role}})
-    token = hashlib.sha256(uuid.uuid4().hex.encode('utf-8')).hexdigest()
+    token = generate_device_token()
     USER_TOKENS[token] = [client, user, False, "login", {"is_frozen": False, "is_online": True, "last_seen": None, "login_at": None}]
     await save_tokens()
     userr = serialize_public_user(user)

--- a/dispatchers/authentication/get_me.py
+++ b/dispatchers/authentication/get_me.py
@@ -1,9 +1,10 @@
 from fastapi import WebSocket
+from dispatchers.authentication.tokens import generate_device_token
 from dispatchers.utils.error_templates import err_invalid_token
 from dispatchers.utils.serializers import serialize_public_user
 
 
-async def get_me_handler(client: WebSocket, message: dict, USER_TOKENS: dict, proto, ENCRYPTION_KEYS):
+async def get_me_handler(client: WebSocket, message: dict, USER_TOKENS: dict, proto, ENCRYPTION_KEYS, save_tokens):
     token = message.get("device_token")
 
     if not token:
@@ -14,8 +15,11 @@ async def get_me_handler(client: WebSocket, message: dict, USER_TOKENS: dict, pr
         await err_invalid_token(proto, ENCRYPTION_KEYS, client, type="get_me")
         return
 
-    session = USER_TOKENS[token]
+    session = USER_TOKENS.pop(token)
     session[0] = client
+    new_token = generate_device_token()
+    USER_TOKENS[new_token] = session
+    await save_tokens()
 
     user = serialize_public_user(session[1])
 
@@ -23,6 +27,7 @@ async def get_me_handler(client: WebSocket, message: dict, USER_TOKENS: dict, pr
         {
             "is_ok": True,
             "type": "get_me",
+            "token": new_token,
             "user": user
         },
         ENCRYPTION_KEYS[client]['key']

--- a/dispatchers/authentication/register_account.py
+++ b/dispatchers/authentication/register_account.py
@@ -1,7 +1,6 @@
-import hashlib
-import uuid
 from typing import TYPE_CHECKING, Any
 from fastapi import WebSocket
+from dispatchers.authentication.tokens import generate_device_token
 from dispatchers.utils.error_templates import (
     err_user_already_exists,
     err_incompl_request,
@@ -97,7 +96,7 @@ async def server_register_create_user(
     user_doc['_id'] = result.inserted_id
     normalize_user_role(user_doc)
 
-    token = hashlib.sha256(uuid.uuid4().hex.encode('utf-8')).hexdigest()
+    token = generate_device_token()
     USER_TOKENS[token] = [
         client,
         user_doc,

--- a/dispatchers/authentication/tokens.py
+++ b/dispatchers/authentication/tokens.py
@@ -1,0 +1,6 @@
+import hashlib
+import uuid
+
+
+def generate_device_token() -> str:
+    return hashlib.sha256(uuid.uuid4().hex.encode("utf-8")).hexdigest()

--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -248,6 +248,7 @@ Successful response:
 {
   "is_ok": true,
   "type": "get_me",
+  "token": "new-device-token",
   "user": {
     "_id": "user-id",
     "email": "alice@example.com",
@@ -257,6 +258,8 @@ Successful response:
   }
 }
 ```
+
+The supplied `device_token` is rotated on success. Use the returned `token` for subsequent requests; the previous token is invalid after this response.
 
 Known errors:
 

--- a/tests/test_get_me.py
+++ b/tests/test_get_me.py
@@ -13,6 +13,7 @@ async def test_get_me_returns_user_for_valid_session(client, encryption_keys, pr
     user_tokens = {
         token: [client, {"_id": user_id, "login": "alice"}, False, "login", {}]
     }
+    save_tokens = AsyncMock()
 
     await get_me_handler(
         client=client,
@@ -20,16 +21,22 @@ async def test_get_me_returns_user_for_valid_session(client, encryption_keys, pr
         USER_TOKENS=user_tokens,
         proto=proto,
         ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
     )
 
     proto.send_message.assert_awaited_once()
     payload, used_key = proto.send_message.await_args.args
+    new_token = payload["token"]
     assert payload == {
         "is_ok": True,
         "type": "get_me",
+        "token": new_token,
         "user": {"_id": str(user_id), "login": "alice"},
     }
     assert used_key == b"secret"
+    assert token not in user_tokens
+    assert user_tokens[new_token][0] == client
+    save_tokens.assert_awaited_once()
 
 
 async def test_get_me_rebinds_valid_token_from_stale_client(client, encryption_keys, proto):
@@ -39,6 +46,7 @@ async def test_get_me_rebinds_valid_token_from_stale_client(client, encryption_k
     user_tokens = {
         token: [stale_client, {"_id": user_id, "login": "alice"}, False, "login", {}]
     }
+    save_tokens = AsyncMock()
 
     await get_me_handler(
         client=client,
@@ -46,26 +54,73 @@ async def test_get_me_rebinds_valid_token_from_stale_client(client, encryption_k
         USER_TOKENS=user_tokens,
         proto=proto,
         ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
     )
 
-    assert user_tokens[token][0] == client
     proto.send_message.assert_awaited_once()
     payload, used_key = proto.send_message.await_args.args
+    new_token = payload["token"]
     assert payload == {
         "is_ok": True,
         "type": "get_me",
+        "token": new_token,
         "user": {"_id": str(user_id), "login": "alice"},
     }
     assert used_key == b"secret"
+    assert token not in user_tokens
+    assert new_token in user_tokens
+    assert user_tokens[new_token][0] == client
+    save_tokens.assert_awaited_once()
+
+
+async def test_get_me_invalidates_old_token_after_success(client, encryption_keys, proto):
+    old_token = "token-1"
+    user_tokens = {
+        old_token: [client, {"_id": ObjectId(), "login": "alice"}, False, "login", {}]
+    }
+    save_tokens = AsyncMock()
+
+    await get_me_handler(
+        client=client,
+        message={"device_token": old_token},
+        USER_TOKENS=user_tokens,
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
+    )
+
+    rotated_token = proto.send_message.await_args.args[0]["token"]
+    proto.send_message.reset_mock()
+
+    await get_me_handler(
+        client=client,
+        message={"device_token": old_token},
+        USER_TOKENS=user_tokens,
+        proto=proto,
+        ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
+    )
+
+    await asyncio.sleep(0)
+    assert old_token not in user_tokens
+    assert rotated_token in user_tokens
+    assert save_tokens.await_count == 1
+    payload, _ = proto.send_message.await_args.args
+    assert payload["is_ok"] is False
+    assert payload["type"] == "get_me"
+    assert payload["err_code"] == "#INSECURE_CONNECTION"
 
 
 async def test_get_me_rejects_missing_token(client, encryption_keys, proto):
+    save_tokens = AsyncMock()
+
     await get_me_handler(
         client=client,
         message={},
         USER_TOKENS={},
         proto=proto,
         ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
     )
 
     await asyncio.sleep(0)
@@ -75,15 +130,19 @@ async def test_get_me_rejects_missing_token(client, encryption_keys, proto):
     assert payload["type"] == "get_me"
     assert payload["error"] == "Unable to establish a secure connection. Please try again later."
     assert payload["err_code"] == "#INSECURE_CONNECTION"
+    save_tokens.assert_not_awaited()
 
 
 async def test_get_me_rejects_invalid_token(client, encryption_keys, proto):
+    save_tokens = AsyncMock()
+
     await get_me_handler(
         client=client,
         message={"device_token": "missing"},
         USER_TOKENS={},
         proto=proto,
         ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
     )
 
     await asyncio.sleep(0)
@@ -93,6 +152,7 @@ async def test_get_me_rejects_invalid_token(client, encryption_keys, proto):
     assert payload["type"] == "get_me"
     assert payload["error"] == "Unable to establish a secure connection. Please try again later."
     assert payload["err_code"] == "#INSECURE_CONNECTION"
+    save_tokens.assert_not_awaited()
 
 
 async def test_logout_can_revoke_token_after_get_me_rebinds(client, encryption_keys, proto):
@@ -109,11 +169,13 @@ async def test_logout_can_revoke_token_after_get_me_rebinds(client, encryption_k
         USER_TOKENS=user_tokens,
         proto=proto,
         ENCRYPTION_KEYS=encryption_keys,
+        save_tokens=save_tokens,
     )
+    new_token = proto.send_message.await_args.args[0]["token"]
 
     await logout_handler(
         client=client,
-        message={"device_token": token},
+        message={"device_token": new_token},
         USER_TOKENS=user_tokens,
         proto=proto,
         ENCRYPTION_KEYS=encryption_keys,
@@ -121,7 +183,8 @@ async def test_logout_can_revoke_token_after_get_me_rebinds(client, encryption_k
     )
 
     assert token not in user_tokens
-    save_tokens.assert_awaited_once()
+    assert new_token not in user_tokens
+    assert save_tokens.await_count == 2
     assert proto.send_message.await_count == 2
     logout_payload, used_key = proto.send_message.await_args.args
     assert logout_payload == {

--- a/websocket.py
+++ b/websocket.py
@@ -42,7 +42,8 @@ async def message_handler(websocket: WebSocket, message: str):
             message=message,
             USER_TOKENS=USER_TOKENS,
             proto=proto,
-            ENCRYPTION_KEYS=ENCRYPTION_KEYS
+            ENCRYPTION_KEYS=ENCRYPTION_KEYS,
+            save_tokens=save_tokens
         )
 
     elif message['type'] == "logout":


### PR DESCRIPTION
- add shared device token generator helper
- rotate valid get_me tokens and persist via save_tokens
- invalidate old token while rebinding session to current websocket client
- return new token in get_me response
- update websocket contract docs/schema
- add tests for rotation, old-token invalidation, and error cases